### PR TITLE
Make reqwest client clonable

### DIFF
--- a/src/reqwest.rs
+++ b/src/reqwest.rs
@@ -25,7 +25,7 @@ use typed_builder::TypedBuilder;
 ///   .token("<sometoken>")
 ///   .build();
 /// ```
-#[derive(TypedBuilder)]
+#[derive(TypedBuilder, Clone)]
 pub struct PostmarkClient {
     #[builder(default, setter(into, strip_option))]
     pub token: Option<String>,


### PR DESCRIPTION
To be able to use this library together with Axum, I had to add the Clone derive to PostmarkClient.

Seems to still build and works with my repo, so not sure if I need to do anything else here?

Thanks! 🙏🏻 