### PR TITLE
Fix docs formatting

### DIFF
--- a/src/api/email/send_email.rs
+++ b/src/api/email/send_email.rs
@@ -18,7 +18,7 @@ use typed_builder::TypedBuilder;
 #[derive(TypedBuilder)]
 pub struct SendEmailRequest {
     /// The sender email address. Must have a registered and confirmed Sender Signature.
-    /// To include a name, use the format "Full Name <sender@domain.com>" for the address.
+    /// To include a name, use the format `Full Name <sender@domain.com>` for the address.
     #[builder(setter(into))]
     pub from: String,
 

--- a/src/api/email/send_email_with_template.rs
+++ b/src/api/email/send_email_with_template.rs
@@ -96,7 +96,7 @@ impl<K: Into<String>, V: Serialize> From<indexmap::IndexMap<K, V>> for TemplateM
 #[derive(TypedBuilder)]
 pub struct SendEmailWithTemplateRequest {
     /// The sender email address. Must have a registered and confirmed Sender Signature.
-    /// To include a name, use the format "Full Name <sender@domain.com>" for the address.
+    /// To include a name, use the format `Full Name <sender@domain.com>` for the address.
     #[builder(setter(into))]
     pub from: String,
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4283010/233841484-b3116dbb-1746-4340-bc10-9d8316a0da67.png)


Note the missing `<` and `>` in rendered docs.