### PR TITLE
Actually fix unit tests

### DIFF
--- a/src/api/email/send_email.rs
+++ b/src/api/email/send_email.rs
@@ -90,15 +90,15 @@ pub struct SendEmailRequest {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Body {
-    Text{
+    Text {
         #[serde(rename = "TextBody")]
         text: String,
     },
-    Html{
+    Html {
         #[serde(rename = "HtmlBody")]
         html: String,
     },
-    HtmlAndText{
+    HtmlAndText {
         #[serde(rename = "HtmlBody")]
         html: String,
         #[serde(rename = "TextBody")]
@@ -108,7 +108,7 @@ pub enum Body {
 
 impl Default for Body {
     fn default() -> Self {
-        Body::Text{text: "".into()}
+        Body::Text { text: "".into() }
     }
 }
 
@@ -340,7 +340,6 @@ mod tests {
         req.execute(&client)
             .await
             .expect("Should get a response and be able to json decode it");
-
     }
 
     #[tokio::test]

--- a/src/api/email/send_email.rs
+++ b/src/api/email/send_email.rs
@@ -27,7 +27,7 @@ pub struct SendEmailRequest {
     pub to: String,
 
     /// The body of the message
-    // -> THIS DOES NOT WORK #[serde(flatten)]
+    // #[serde(flatten)]
     pub body: Body,
 
     /// Cc recipient email address. Multiple addresses are comma separated. Max 50.
@@ -94,18 +94,21 @@ pub enum Body {
     Text(String),
     #[serde(rename = "HtmlBody")]
     Html(String),
-    HtmlAndText {
-        #[serde(rename = "HtmlBody")]
-        html: String,
-        #[serde(rename = "TextBody")]
-        text: String,
-    },
+    HtmlAndText(HtmlAndText),
 }
 
 impl Default for Body {
     fn default() -> Self {
         Body::Text("".into())
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct HtmlAndText {
+    #[serde(flatten, rename = "HtmlBody")]
+    pub html: String,
+    #[serde(flatten, rename = "TextBody")]
+    pub text: String,
 }
 
 /// A custom headers to include in a email.

--- a/src/api/email/send_email.rs
+++ b/src/api/email/send_email.rs
@@ -10,7 +10,7 @@ use typed_builder::TypedBuilder;
 /// let req = SendEmailRequest::builder()
 ///   .from("me@example.com")
 ///   .to("you@example.com")
-///   .body(Body::Text("Hi, this is me!".to_string()))
+///   .body(Body::text("Hi, this is me!".to_string()))
 ///   .build();
 /// ```
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
@@ -27,7 +27,7 @@ pub struct SendEmailRequest {
     pub to: String,
 
     /// The body of the message
-    // #[serde(flatten)]
+    #[serde(flatten)]
     pub body: Body,
 
     /// Cc recipient email address. Multiple addresses are comma separated. Max 50.
@@ -90,25 +90,41 @@ pub struct SendEmailRequest {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Body {
-    #[serde(rename = "TextBody")]
-    Text(String),
-    #[serde(rename = "HtmlBody")]
-    Html(String),
-    HtmlAndText(HtmlAndText),
+    Text{
+        #[serde(rename = "TextBody")]
+        text: String,
+    },
+    Html{
+        #[serde(rename = "HtmlBody")]
+        html: String,
+    },
+    HtmlAndText{
+        #[serde(rename = "HtmlBody")]
+        html: String,
+        #[serde(rename = "TextBody")]
+        text: String,
+    },
 }
 
 impl Default for Body {
     fn default() -> Self {
-        Body::Text("".into())
+        Body::Text{text: "".into()}
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct HtmlAndText {
-    #[serde(flatten, rename = "HtmlBody")]
-    pub html: String,
-    #[serde(flatten, rename = "TextBody")]
-    pub text: String,
+impl Body {
+    /// Constructor to create a text-only [`Body`] enum
+    pub fn text(text: String) -> Self {
+        Body::Text { text }
+    }
+    /// Constructor to create a html-only [`Body`] enum
+    pub fn html(html: String) -> Self {
+        Body::Html { html }
+    }
+    /// Constructor to create a text and html [`Body`] enum
+    pub fn html_and_text(html: String, text: String) -> Self {
+        Body::HtmlAndText { html, text }
+    }
 }
 
 /// A custom headers to include in a email.
@@ -181,12 +197,18 @@ mod tests {
     use httptest::{responders::*, Expectation, Server};
     use serde_json::json;
 
-    use super::{Body, SendEmailRequest};
+    use super::*;
     use crate::reqwest::PostmarkClient;
     use crate::Query;
 
+    const FROM: &str = "pa@example.com";
+    const TO: &str = "mathieu@example.com";
+    const TEXT_BODY: &str = "hello matt";
+    const HTML_BODY: &str = "<html><body><strong>Hello</strong> dear Postmark user.</body></html>";
+    const SUBJ: &str = "hello";
+
     #[tokio::test]
-    pub async fn send_email_test() {
+    pub async fn send_email_test_with_text() {
         let server = Server::run();
 
         server.expect(
@@ -206,15 +228,111 @@ mod tests {
             .build();
 
         let req = SendEmailRequest::builder()
-            .from("pa@example.com")
-            .to("mathieu@example.com")
-            .body(Body::Text("hello matt".into()))
-            .subject("hello")
+            .from(FROM)
+            .to(TO)
+            .body(Body::text(TEXT_BODY.into()))
+            .subject(SUBJ)
             .build();
+
+        assert_eq!(
+            serde_json::to_value(&req).unwrap(),
+            json!({
+                "From": FROM,
+                "To": TO,
+                "TextBody": TEXT_BODY,
+                "Subject": SUBJ,
+            })
+        );
 
         req.execute(&client)
             .await
             .expect("Should get a response and be able to json decode it");
+    }
+
+    #[tokio::test]
+    pub async fn send_email_test_with_html() {
+        let server = Server::run();
+
+        server.expect(
+            Expectation::matching(request::method_path("POST", "/email")).respond_with(
+                json_encoded(json!({
+                    "To": "receiver@example.com",
+                    "SubmittedAt": "2014-02-17T07:25:01.4178645-05:00",
+                    "MessageID": "0a129aee-e1cd-480d-b08d-4f48548ff48d",
+                    "ErrorCode": 0,
+                    "Message": "OK"
+                })),
+            ),
+        );
+
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+
+        let req = SendEmailRequest::builder()
+            .from(FROM)
+            .to(TO)
+            .body(Body::html(HTML_BODY.into()))
+            .subject(SUBJ)
+            .build();
+
+        assert_eq!(
+            serde_json::to_value(&req).unwrap(),
+            json!({
+                "From": FROM,
+                "To": TO,
+                "HtmlBody": HTML_BODY,
+                "Subject": SUBJ,
+            })
+        );
+
+        req.execute(&client)
+            .await
+            .expect("Should get a response and be able to json decode it");
+    }
+
+    #[tokio::test]
+    pub async fn send_email_test_with_html_and_text() {
+        let server = Server::run();
+
+        server.expect(
+            Expectation::matching(request::method_path("POST", "/email")).respond_with(
+                json_encoded(json!({
+                    "To": "receiver@example.com",
+                    "SubmittedAt": "2014-02-17T07:25:01.4178645-05:00",
+                    "MessageID": "0a129aee-e1cd-480d-b08d-4f48548ff48d",
+                    "ErrorCode": 0,
+                    "Message": "OK"
+                })),
+            ),
+        );
+
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+
+        let req = SendEmailRequest::builder()
+            .from(FROM)
+            .to(TO)
+            .body(Body::html_and_text(HTML_BODY.into(), TEXT_BODY.into()))
+            .subject(SUBJ)
+            .build();
+
+        assert_eq!(
+            serde_json::to_value(&req).unwrap(),
+            json!({
+                "From": FROM,
+                "To": TO,
+                "HtmlBody": HTML_BODY,
+                "TextBody": TEXT_BODY,
+                "Subject": SUBJ,
+            })
+        );
+
+        req.execute(&client)
+            .await
+            .expect("Should get a response and be able to json decode it");
+
     }
 
     #[tokio::test]
@@ -236,7 +354,7 @@ mod tests {
         let req = SendEmailRequest::builder()
             .from("pa@example.com")
             .to("mathieu@example.com")
-            .body(Body::Text("hello matt".into()))
+            .body(Body::text("hello matt".into()))
             .subject("hello")
             .build();
 

--- a/src/api/email/send_email.rs
+++ b/src/api/email/send_email.rs
@@ -27,7 +27,7 @@ pub struct SendEmailRequest {
     pub to: String,
 
     /// The body of the message
-    #[serde(flatten)]
+    // -> THIS DOES NOT WORK #[serde(flatten)]
     pub body: Body,
 
     /// Cc recipient email address. Multiple addresses are comma separated. Max 50.

--- a/src/api/email/send_email_batch.rs
+++ b/src/api/email/send_email_batch.rs
@@ -56,7 +56,7 @@ mod tests {
 
         let req_builder = SendEmailRequest::builder()
             .from("pa@example.com")
-            .body(Body::Text("hello matt".into()))
+            .body(Body::text("hello matt".into()))
             .subject("hello");
 
         let req: SendEmailBatchRequest = vec![

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //! let req = api::email::SendEmailRequest::builder()
 //!   .from("me@example.com")
 //!   .to("you@example.com")
-//!   .body(api::email::Body::Text("Hi, this is me!".to_string()))
+//!   .body(api::email::Body::text("Hi, this is me!".to_string()))
 //!   .build();
 //! let resp = req.execute(&client).await;
 //! resp.unwrap();


### PR DESCRIPTION
While unit tests passed, the previous PR did not create the correct JSON structure. 

In order to get the `Body` Enum to universally flatten, I propose making each Enum variant a struct so that flatten will pull the correct fields into the `SendEmailRequest`.

In order to minimize changes from the previous ways of instantiating the `Body` Enum, I add helper constructors.

In order to ensure that this functionality works, I add unit tests to assert that the created JSON Value from serializing the object is as expected. 