### PR TITLE
fix domains endpoint casing and SPF verify response

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -8,6 +8,7 @@
 use serde::{Deserialize, Serialize};
 
 pub mod bounce;
+pub mod domains;
 pub mod email;
 pub mod message_streams;
 pub mod server;

--- a/src/api/bounce/delivery_stats.rs
+++ b/src/api/bounce/delivery_stats.rs
@@ -24,7 +24,6 @@ impl Endpoint for DeliveryStatsRequest {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "PascalCase")]
-
 pub struct DeliveryStatsResponse {
     #[serde(rename = "InactiveMails")]
     /// Number of inactive emails

--- a/src/api/domains.rs
+++ b/src/api/domains.rs
@@ -1,0 +1,121 @@
+//! Domains API endpoints for managing domain details in a Postmark account.
+
+pub use create_domain::*;
+pub use delete_domain::*;
+pub use edit_domain::*;
+pub use get_domain::*;
+pub use list_domains::*;
+pub use rotate_dkim::*;
+pub use verify_dkim::*;
+pub use verify_return_path::*;
+pub use verify_spf::*;
+
+use serde::{Deserialize, Serialize};
+
+mod create_domain;
+mod delete_domain;
+mod edit_domain;
+mod get_domain;
+mod list_domains;
+mod rotate_dkim;
+mod verify_dkim;
+mod verify_return_path;
+mod verify_spf;
+
+/// Status of a DKIM update operation.
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+pub enum DkimUpdateStatus {
+    /// DKIM renewal or setup is in progress.
+    #[default]
+    Pending,
+    /// All DNS TXT records are up to date and any pending operations are finished.
+    Verified,
+    /// DKIM verification failed.
+    Failed,
+    /// Catch-all for any status not yet represented in this enum.
+    #[serde(untagged)]
+    Unknown(String),
+}
+
+/// Summary of a domain as returned by the list domains endpoint.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct DomainSummary {
+    /// Domain name.
+    pub name: String,
+    /// Deprecated. See Postmark's blog post on why SPF records are no longer required.
+    #[serde(rename = "SPFVerified")]
+    pub spf_verified: bool,
+    /// Whether DKIM has ever been verified for the domain.
+    /// Once verified, this stays true even if the record is later removed from DNS.
+    #[serde(rename = "DKIMVerified")]
+    pub dkim_verified: bool,
+    /// Whether DKIM is using a strength weaker than 1024 bit.
+    #[serde(rename = "WeakDKIM")]
+    pub weak_dkim: bool,
+    /// Whether the Return-Path domain is actively being used.
+    pub return_path_domain_verified: bool,
+    /// Unique ID of the domain.
+    #[serde(rename = "ID")]
+    pub id: i64,
+}
+
+/// Full domain details as returned by get, create, edit, and verify endpoints.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct DomainDetails {
+    /// Domain name.
+    pub name: String,
+    /// Deprecated. See Postmark's blog post on why SPF records are no longer required.
+    #[serde(rename = "SPFVerified")]
+    pub spf_verified: bool,
+    /// Host name used for the SPF configuration.
+    #[serde(rename = "SPFHost")]
+    pub spf_host: String,
+    /// Value that can be optionally set up with your DNS host for SPF verification.
+    #[serde(rename = "SPFTextValue")]
+    pub spf_text_value: String,
+    /// Whether DKIM has ever been verified for the domain.
+    /// Once verified, this stays true even if the record is later removed from DNS.
+    #[serde(rename = "DKIMVerified")]
+    pub dkim_verified: bool,
+    /// Whether DKIM is using a strength weaker than 1024 bit.
+    /// If so, you can request a new DKIM via [`RotateDkimRequest`].
+    #[serde(rename = "WeakDKIM")]
+    pub weak_dkim: bool,
+    /// DNS TXT host being used to validate messages sent in.
+    #[serde(rename = "DKIMHost")]
+    pub dkim_host: String,
+    /// DNS TXT value being used to validate messages sent in.
+    #[serde(rename = "DKIMTextValue")]
+    pub dkim_text_value: String,
+    /// Pending DKIM DNS TXT host awaiting setup and confirmation at your registrar or DNS host.
+    #[serde(rename = "DKIMPendingHost")]
+    pub dkim_pending_host: String,
+    /// Pending DKIM DNS TXT value awaiting confirmation at your registrar or DNS host.
+    #[serde(rename = "DKIMPendingTextValue")]
+    pub dkim_pending_text_value: String,
+    /// The old DKIM host that Postmark has revoked after a new DKIM was confirmed.
+    #[serde(rename = "DKIMRevokedHost")]
+    pub dkim_revoked_host: String,
+    /// The old DKIM DNS TXT value that will soon be removed from the Postmark system.
+    #[serde(rename = "DKIMRevokedTextValue")]
+    pub dkim_revoked_text_value: String,
+    /// Whether you may safely delete the old revoked DKIM DNS TXT records.
+    #[serde(rename = "SafeToRemoveRevokedKeyFromDNS")]
+    pub safe_to_remove_revoked_key_from_dns: bool,
+    /// DKIM update status.
+    #[serde(rename = "DKIMUpdateStatus")]
+    pub dkim_update_status: DkimUpdateStatus,
+    /// Custom Return-Path domain. Must be a subdomain of your From Email domain
+    /// with a CNAME record pointing to `pm.mtasv.net`.
+    pub return_path_domain: String,
+    /// Whether the Return-Path domain is actively being used.
+    pub return_path_domain_verified: bool,
+    /// The CNAME DNS record that Postmark expects to find at the Return-Path domain.
+    #[serde(rename = "ReturnPathDomainCNAMEValue")]
+    pub return_path_domain_cname_value: String,
+    /// Unique ID of the domain.
+    #[serde(rename = "ID")]
+    pub id: i64,
+}

--- a/src/api/domains.rs
+++ b/src/api/domains.rs
@@ -57,7 +57,7 @@ pub struct DomainSummary {
     pub return_path_domain_verified: bool,
     /// Unique ID of the domain.
     #[serde(rename = "ID")]
-    pub id: i64,
+    pub id: isize,
 }
 
 /// Full domain details as returned by get, create, edit, and verify endpoints.
@@ -117,5 +117,5 @@ pub struct DomainDetails {
     pub return_path_domain_cname_value: String,
     /// Unique ID of the domain.
     #[serde(rename = "ID")]
-    pub id: i64,
+    pub id: isize,
 }

--- a/src/api/domains/create_domain.rs
+++ b/src/api/domains/create_domain.rs
@@ -1,0 +1,158 @@
+use std::borrow::Cow;
+
+use crate::api::domains::DomainDetails;
+use crate::Endpoint;
+use serde::Serialize;
+use typed_builder::TypedBuilder;
+
+/// Create a new domain.
+///
+/// ```
+/// use postmark::api::domains::CreateDomainRequest;
+/// let req = CreateDomainRequest::builder()
+///   .name("example.com")
+///   .return_path_domain("pm-bounces.example.com")
+///   .build();
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "PascalCase")]
+#[derive(TypedBuilder)]
+pub struct CreateDomainRequest {
+    /// Domain name to register.
+    #[builder(setter(into))]
+    pub name: String,
+    /// Optional custom Return-Path domain. Must be a subdomain of your From Email domain
+    /// with a CNAME record pointing to `pm.mtasv.net`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(into, strip_option))]
+    pub return_path_domain: Option<String>,
+}
+
+impl Endpoint for CreateDomainRequest {
+    type Request = CreateDomainRequest;
+    type Response = DomainDetails;
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        "/domains".into()
+    }
+
+    fn body(&self) -> &Self::Request {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httptest::matchers::request;
+    use httptest::{responders::*, Expectation, Server};
+    use serde_json::json;
+
+    use crate::reqwest::PostmarkClient;
+    use crate::Query;
+
+    use super::*;
+
+    #[tokio::test]
+    pub async fn create_domain() {
+        let server = Server::run();
+
+        server.expect(
+            Expectation::matching(request::method_path("POST", "/domains")).respond_with(
+                json_encoded(json!({
+                    "Name": "newdomain.com",
+                    "SPFVerified": false,
+                    "SPFHost": "newdomain.com",
+                    "SPFTextValue": "v=spf1 a mx include:spf.mtasv.net ~all",
+                    "DKIMVerified": false,
+                    "WeakDKIM": false,
+                    "DKIMHost": "",
+                    "DKIMTextValue": "",
+                    "DKIMPendingHost": "20131031155228pm._domainkey.newdomain.com",
+                    "DKIMPendingTextValue": "k=rsa;p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCFn...",
+                    "DKIMRevokedHost": "",
+                    "DKIMRevokedTextValue": "",
+                    "SafeToRemoveRevokedKeyFromDNS": false,
+                    "DKIMUpdateStatus": "Pending",
+                    "ReturnPathDomain": "pm-bounces.newdomain.com",
+                    "ReturnPathDomainVerified": false,
+                    "ReturnPathDomainCNAMEValue": "pm.mtasv.net",
+                    "ID": 36736
+                })),
+            ),
+        );
+
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+
+        let req = CreateDomainRequest::builder()
+            .name("newdomain.com")
+            .return_path_domain("pm-bounces.newdomain.com")
+            .build();
+
+        assert_eq!(
+            serde_json::to_value(&req).unwrap(),
+            json!({
+                "Name": "newdomain.com",
+                "ReturnPathDomain": "pm-bounces.newdomain.com",
+            })
+        );
+
+        let resp = req
+            .execute(&client)
+            .await
+            .expect("Should get a response and be able to json decode it");
+
+        assert_eq!(resp.name, "newdomain.com");
+        assert_eq!(resp.id, 36736);
+    }
+
+    #[tokio::test]
+    pub async fn create_domain_without_return_path() {
+        let server = Server::run();
+
+        server.expect(
+            Expectation::matching(request::method_path("POST", "/domains")).respond_with(
+                json_encoded(json!({
+                    "Name": "newdomain.com",
+                    "SPFVerified": false,
+                    "SPFHost": "newdomain.com",
+                    "SPFTextValue": "v=spf1 a mx include:spf.mtasv.net ~all",
+                    "DKIMVerified": false,
+                    "WeakDKIM": false,
+                    "DKIMHost": "",
+                    "DKIMTextValue": "",
+                    "DKIMPendingHost": "",
+                    "DKIMPendingTextValue": "",
+                    "DKIMRevokedHost": "",
+                    "DKIMRevokedTextValue": "",
+                    "SafeToRemoveRevokedKeyFromDNS": false,
+                    "DKIMUpdateStatus": "Pending",
+                    "ReturnPathDomain": "",
+                    "ReturnPathDomainVerified": false,
+                    "ReturnPathDomainCNAMEValue": "",
+                    "ID": 36737
+                })),
+            ),
+        );
+
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+
+        let req = CreateDomainRequest::builder()
+            .name("newdomain.com")
+            .build();
+
+        assert_eq!(
+            serde_json::to_value(&req).unwrap(),
+            json!({
+                "Name": "newdomain.com",
+            })
+        );
+
+        req.execute(&client)
+            .await
+            .expect("Should get a response and be able to json decode it");
+    }
+}

--- a/src/api/domains/create_domain.rs
+++ b/src/api/domains/create_domain.rs
@@ -140,9 +140,7 @@ mod tests {
             .base_url(server.url("/").to_string())
             .build();
 
-        let req = CreateDomainRequest::builder()
-            .name("newdomain.com")
-            .build();
+        let req = CreateDomainRequest::builder().name("newdomain.com").build();
 
         assert_eq!(
             serde_json::to_value(&req).unwrap(),

--- a/src/api/domains/delete_domain.rs
+++ b/src/api/domains/delete_domain.rs
@@ -18,7 +18,7 @@ use typed_builder::TypedBuilder;
 pub struct DeleteDomainRequest {
     /// Unique ID of the domain to delete.
     #[serde(skip)]
-    pub domain_id: i64,
+    pub domain_id: isize,
 }
 
 /// Response for the [`DeleteDomainRequest`] endpoint.
@@ -62,7 +62,7 @@ mod tests {
 
     use super::*;
 
-    const DOMAIN_ID: i64 = 36735;
+    const DOMAIN_ID: isize = 36735;
 
     #[tokio::test]
     pub async fn delete_domain() {
@@ -83,9 +83,7 @@ mod tests {
             .base_url(server.url("/").to_string())
             .build();
 
-        let req = DeleteDomainRequest::builder()
-            .domain_id(DOMAIN_ID)
-            .build();
+        let req = DeleteDomainRequest::builder().domain_id(DOMAIN_ID).build();
 
         let resp = req
             .execute(&client)

--- a/src/api/domains/delete_domain.rs
+++ b/src/api/domains/delete_domain.rs
@@ -1,0 +1,98 @@
+use std::borrow::Cow;
+
+use crate::Endpoint;
+use serde::{Deserialize, Serialize};
+use typed_builder::TypedBuilder;
+
+/// Delete a domain.
+///
+/// ```
+/// use postmark::api::domains::DeleteDomainRequest;
+/// let req = DeleteDomainRequest::builder()
+///   .domain_id(36735)
+///   .build();
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "PascalCase")]
+#[derive(TypedBuilder)]
+pub struct DeleteDomainRequest {
+    /// Unique ID of the domain to delete.
+    #[serde(skip)]
+    pub domain_id: i64,
+}
+
+/// Response for the [`DeleteDomainRequest`] endpoint.
+///
+/// On success, `error_code` will be 0.
+/// On failure, details will be held in `error_code` and `message`.
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct DeleteDomainResponse {
+    /// [API Error codes](https://postmarkapp.com/developer/api/overview#error-codes)
+    pub error_code: i64,
+    /// Associated success or error message.
+    pub message: String,
+}
+
+impl Endpoint for DeleteDomainRequest {
+    type Request = DeleteDomainRequest;
+    type Response = DeleteDomainResponse;
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("/domains/{}", self.domain_id).into()
+    }
+
+    fn body(&self) -> &Self::Request {
+        self
+    }
+
+    fn method(&self) -> http::Method {
+        http::Method::DELETE
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httptest::matchers::request;
+    use httptest::{responders::*, Expectation, Server};
+    use serde_json::json;
+
+    use crate::reqwest::PostmarkClient;
+    use crate::Query;
+
+    use super::*;
+
+    const DOMAIN_ID: i64 = 36735;
+
+    #[tokio::test]
+    pub async fn delete_domain() {
+        let server = Server::run();
+
+        server.expect(
+            Expectation::matching(request::method_path(
+                "DELETE",
+                format!("/domains/{DOMAIN_ID}"),
+            ))
+            .respond_with(json_encoded(json!({
+                "ErrorCode": 0,
+                "Message": "Domain example.com removed."
+            }))),
+        );
+
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+
+        let req = DeleteDomainRequest::builder()
+            .domain_id(DOMAIN_ID)
+            .build();
+
+        let resp = req
+            .execute(&client)
+            .await
+            .expect("Should get a response and be able to json decode it");
+
+        assert_eq!(resp.error_code, 0);
+        assert_eq!(resp.message, "Domain example.com removed.");
+    }
+}

--- a/src/api/domains/edit_domain.rs
+++ b/src/api/domains/edit_domain.rs
@@ -62,30 +62,27 @@ mod tests {
         let server = Server::run();
 
         server.expect(
-            Expectation::matching(request::method_path(
-                "PUT",
-                format!("/domains/{DOMAIN_ID}"),
-            ))
-            .respond_with(json_encoded(json!({
-                "Name": "example.com",
-                "SPFVerified": false,
-                "SPFHost": "example.com",
-                "SPFTextValue": "v=spf1 a mx include:spf.mtasv.net ~all",
-                "DKIMVerified": false,
-                "WeakDKIM": false,
-                "DKIMHost": "20160921046319pm._domainkey.example.com",
-                "DKIMTextValue": "k=rsa;p=MIGfMA0GDRrFQJc5dZEBAQUAA4GNADCBiQKBgQCFn...",
-                "DKIMPendingHost": "20131031155228pm._domainkey.example.com",
-                "DKIMPendingTextValue": "k=rsa;p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCFn...",
-                "DKIMRevokedHost": "",
-                "DKIMRevokedTextValue": "",
-                "SafeToRemoveRevokedKeyFromDNS": false,
-                "DKIMUpdateStatus": "Pending",
-                "ReturnPathDomain": "pm-bounces.example.com",
-                "ReturnPathDomainVerified": false,
-                "ReturnPathDomainCNAMEValue": "pm.mtasv.net",
-                "ID": 36736
-            }))),
+            Expectation::matching(request::method_path("PUT", format!("/domains/{DOMAIN_ID}")))
+                .respond_with(json_encoded(json!({
+                    "Name": "example.com",
+                    "SPFVerified": false,
+                    "SPFHost": "example.com",
+                    "SPFTextValue": "v=spf1 a mx include:spf.mtasv.net ~all",
+                    "DKIMVerified": false,
+                    "WeakDKIM": false,
+                    "DKIMHost": "20160921046319pm._domainkey.example.com",
+                    "DKIMTextValue": "k=rsa;p=MIGfMA0GDRrFQJc5dZEBAQUAA4GNADCBiQKBgQCFn...",
+                    "DKIMPendingHost": "20131031155228pm._domainkey.example.com",
+                    "DKIMPendingTextValue": "k=rsa;p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCFn...",
+                    "DKIMRevokedHost": "",
+                    "DKIMRevokedTextValue": "",
+                    "SafeToRemoveRevokedKeyFromDNS": false,
+                    "DKIMUpdateStatus": "Pending",
+                    "ReturnPathDomain": "pm-bounces.example.com",
+                    "ReturnPathDomainVerified": false,
+                    "ReturnPathDomainCNAMEValue": "pm.mtasv.net",
+                    "ID": 36736
+                }))),
         );
 
         let client = PostmarkClient::builder()

--- a/src/api/domains/edit_domain.rs
+++ b/src/api/domains/edit_domain.rs
@@ -20,7 +20,7 @@ use typed_builder::TypedBuilder;
 pub struct EditDomainRequest {
     /// Unique ID of the domain to edit.
     #[serde(skip)]
-    pub domain_id: i64,
+    pub domain_id: isize,
     /// Custom Return-Path domain. Must be a subdomain of your From Email domain
     /// with a CNAME record pointing to `pm.mtasv.net`.
     #[builder(setter(into))]
@@ -55,7 +55,7 @@ mod tests {
 
     use super::*;
 
-    const DOMAIN_ID: i64 = 36736;
+    const DOMAIN_ID: isize = 36736;
 
     #[tokio::test]
     pub async fn edit_domain() {

--- a/src/api/domains/edit_domain.rs
+++ b/src/api/domains/edit_domain.rs
@@ -1,0 +1,115 @@
+use std::borrow::Cow;
+
+use crate::api::domains::DomainDetails;
+use crate::Endpoint;
+use serde::Serialize;
+use typed_builder::TypedBuilder;
+
+/// Edit an existing domain. Only the ReturnPathDomain can be modified.
+///
+/// ```
+/// use postmark::api::domains::EditDomainRequest;
+/// let req = EditDomainRequest::builder()
+///   .domain_id(36735)
+///   .return_path_domain("pm-bounces.example.com")
+///   .build();
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "PascalCase")]
+#[derive(TypedBuilder)]
+pub struct EditDomainRequest {
+    /// Unique ID of the domain to edit.
+    #[serde(skip)]
+    pub domain_id: i64,
+    /// Custom Return-Path domain. Must be a subdomain of your From Email domain
+    /// with a CNAME record pointing to `pm.mtasv.net`.
+    #[builder(setter(into))]
+    pub return_path_domain: String,
+}
+
+impl Endpoint for EditDomainRequest {
+    type Request = EditDomainRequest;
+    type Response = DomainDetails;
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("/domains/{}", self.domain_id).into()
+    }
+
+    fn body(&self) -> &Self::Request {
+        self
+    }
+
+    fn method(&self) -> http::Method {
+        http::Method::PUT
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httptest::matchers::request;
+    use httptest::{responders::*, Expectation, Server};
+    use serde_json::json;
+
+    use crate::reqwest::PostmarkClient;
+    use crate::Query;
+
+    use super::*;
+
+    const DOMAIN_ID: i64 = 36736;
+
+    #[tokio::test]
+    pub async fn edit_domain() {
+        let server = Server::run();
+
+        server.expect(
+            Expectation::matching(request::method_path(
+                "PUT",
+                format!("/domains/{DOMAIN_ID}"),
+            ))
+            .respond_with(json_encoded(json!({
+                "Name": "example.com",
+                "SPFVerified": false,
+                "SPFHost": "example.com",
+                "SPFTextValue": "v=spf1 a mx include:spf.mtasv.net ~all",
+                "DKIMVerified": false,
+                "WeakDKIM": false,
+                "DKIMHost": "20160921046319pm._domainkey.example.com",
+                "DKIMTextValue": "k=rsa;p=MIGfMA0GDRrFQJc5dZEBAQUAA4GNADCBiQKBgQCFn...",
+                "DKIMPendingHost": "20131031155228pm._domainkey.example.com",
+                "DKIMPendingTextValue": "k=rsa;p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCFn...",
+                "DKIMRevokedHost": "",
+                "DKIMRevokedTextValue": "",
+                "SafeToRemoveRevokedKeyFromDNS": false,
+                "DKIMUpdateStatus": "Pending",
+                "ReturnPathDomain": "pm-bounces.example.com",
+                "ReturnPathDomainVerified": false,
+                "ReturnPathDomainCNAMEValue": "pm.mtasv.net",
+                "ID": 36736
+            }))),
+        );
+
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+
+        let req = EditDomainRequest::builder()
+            .domain_id(DOMAIN_ID)
+            .return_path_domain("pm-bounces.example.com")
+            .build();
+
+        assert_eq!(
+            serde_json::to_value(&req).unwrap(),
+            json!({
+                "ReturnPathDomain": "pm-bounces.example.com",
+            })
+        );
+
+        let resp = req
+            .execute(&client)
+            .await
+            .expect("Should get a response and be able to json decode it");
+
+        assert_eq!(resp.return_path_domain, "pm-bounces.example.com");
+        assert_eq!(resp.id, DOMAIN_ID);
+    }
+}

--- a/src/api/domains/get_domain.rs
+++ b/src/api/domains/get_domain.rs
@@ -19,7 +19,7 @@ use typed_builder::TypedBuilder;
 pub struct GetDomainRequest {
     /// Unique ID of the domain to retrieve.
     #[serde(skip)]
-    pub domain_id: i64,
+    pub domain_id: isize,
 }
 
 impl Endpoint for GetDomainRequest {
@@ -50,7 +50,7 @@ mod tests {
 
     use super::*;
 
-    const DOMAIN_ID: i64 = 36735;
+    const DOMAIN_ID: isize = 36735;
 
     #[tokio::test]
     pub async fn get_domain() {

--- a/src/api/domains/get_domain.rs
+++ b/src/api/domains/get_domain.rs
@@ -1,0 +1,100 @@
+use std::borrow::Cow;
+
+use crate::api::domains::DomainDetails;
+use crate::Endpoint;
+use serde::Serialize;
+use typed_builder::TypedBuilder;
+
+/// Get all details for a specific domain.
+///
+/// ```
+/// use postmark::api::domains::GetDomainRequest;
+/// let req = GetDomainRequest::builder()
+///   .domain_id(36735)
+///   .build();
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "PascalCase")]
+#[derive(TypedBuilder)]
+pub struct GetDomainRequest {
+    /// Unique ID of the domain to retrieve.
+    #[serde(skip)]
+    pub domain_id: i64,
+}
+
+impl Endpoint for GetDomainRequest {
+    type Request = GetDomainRequest;
+    type Response = DomainDetails;
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("/domains/{}", self.domain_id).into()
+    }
+
+    fn body(&self) -> &Self::Request {
+        self
+    }
+
+    fn method(&self) -> http::Method {
+        http::Method::GET
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httptest::matchers::request;
+    use httptest::{responders::*, Expectation, Server};
+    use serde_json::json;
+
+    use crate::reqwest::PostmarkClient;
+    use crate::Query;
+
+    use super::*;
+
+    const DOMAIN_ID: i64 = 36735;
+
+    #[tokio::test]
+    pub async fn get_domain() {
+        let server = Server::run();
+
+        server.expect(
+            Expectation::matching(request::method_path(
+                "GET",
+                format!("/domains/{DOMAIN_ID}"),
+            ))
+            .respond_with(json_encoded(json!({
+                "Name": "postmarkapp.com",
+                "SPFVerified": true,
+                "SPFHost": "postmarkapp.com",
+                "SPFTextValue": "v=spf1 a mx include:spf.mtasv.net ~all",
+                "DKIMVerified": false,
+                "WeakDKIM": false,
+                "DKIMHost": "jan2013pm._domainkey.postmarkapp.com",
+                "DKIMTextValue": "k=rsa;p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDJ...",
+                "DKIMPendingHost": "20131031155228pm._domainkey.postmarkapp.com",
+                "DKIMPendingTextValue": "k=rsa;p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCFn...",
+                "DKIMRevokedHost": "",
+                "DKIMRevokedTextValue": "",
+                "SafeToRemoveRevokedKeyFromDNS": false,
+                "DKIMUpdateStatus": "Pending",
+                "ReturnPathDomain": "pm-bounces.postmarkapp.com",
+                "ReturnPathDomainVerified": false,
+                "ReturnPathDomainCNAMEValue": "pm.mtasv.net",
+                "ID": 36735
+            }))),
+        );
+
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+
+        let req = GetDomainRequest::builder().domain_id(DOMAIN_ID).build();
+
+        let resp = req
+            .execute(&client)
+            .await
+            .expect("Should get a response and be able to json decode it");
+
+        assert_eq!(resp.name, "postmarkapp.com");
+        assert_eq!(resp.id, 36735);
+    }
+}

--- a/src/api/domains/get_domain.rs
+++ b/src/api/domains/get_domain.rs
@@ -57,30 +57,27 @@ mod tests {
         let server = Server::run();
 
         server.expect(
-            Expectation::matching(request::method_path(
-                "GET",
-                format!("/domains/{DOMAIN_ID}"),
-            ))
-            .respond_with(json_encoded(json!({
-                "Name": "postmarkapp.com",
-                "SPFVerified": true,
-                "SPFHost": "postmarkapp.com",
-                "SPFTextValue": "v=spf1 a mx include:spf.mtasv.net ~all",
-                "DKIMVerified": false,
-                "WeakDKIM": false,
-                "DKIMHost": "jan2013pm._domainkey.postmarkapp.com",
-                "DKIMTextValue": "k=rsa;p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDJ...",
-                "DKIMPendingHost": "20131031155228pm._domainkey.postmarkapp.com",
-                "DKIMPendingTextValue": "k=rsa;p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCFn...",
-                "DKIMRevokedHost": "",
-                "DKIMRevokedTextValue": "",
-                "SafeToRemoveRevokedKeyFromDNS": false,
-                "DKIMUpdateStatus": "Pending",
-                "ReturnPathDomain": "pm-bounces.postmarkapp.com",
-                "ReturnPathDomainVerified": false,
-                "ReturnPathDomainCNAMEValue": "pm.mtasv.net",
-                "ID": 36735
-            }))),
+            Expectation::matching(request::method_path("GET", format!("/domains/{DOMAIN_ID}")))
+                .respond_with(json_encoded(json!({
+                    "Name": "postmarkapp.com",
+                    "SPFVerified": true,
+                    "SPFHost": "postmarkapp.com",
+                    "SPFTextValue": "v=spf1 a mx include:spf.mtasv.net ~all",
+                    "DKIMVerified": false,
+                    "WeakDKIM": false,
+                    "DKIMHost": "jan2013pm._domainkey.postmarkapp.com",
+                    "DKIMTextValue": "k=rsa;p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDJ...",
+                    "DKIMPendingHost": "20131031155228pm._domainkey.postmarkapp.com",
+                    "DKIMPendingTextValue": "k=rsa;p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCFn...",
+                    "DKIMRevokedHost": "",
+                    "DKIMRevokedTextValue": "",
+                    "SafeToRemoveRevokedKeyFromDNS": false,
+                    "DKIMUpdateStatus": "Pending",
+                    "ReturnPathDomain": "pm-bounces.postmarkapp.com",
+                    "ReturnPathDomainVerified": false,
+                    "ReturnPathDomainCNAMEValue": "pm.mtasv.net",
+                    "ID": 36735
+                }))),
         );
 
         let client = PostmarkClient::builder()

--- a/src/api/domains/list_domains.rs
+++ b/src/api/domains/list_domains.rs
@@ -69,8 +69,8 @@ mod tests {
         let server = Server::run();
 
         server.expect(
-            Expectation::matching(request::method_path("GET", "/domains"))
-                .respond_with(json_encoded(json!({
+            Expectation::matching(request::method_path("GET", "/domains")).respond_with(
+                json_encoded(json!({
                     "TotalCount": 2,
                     "Domains": [
                         {
@@ -90,7 +90,8 @@ mod tests {
                             "ID": 81605
                         }
                     ]
-                }))),
+                })),
+            ),
         );
 
         let client = PostmarkClient::builder()

--- a/src/api/domains/list_domains.rs
+++ b/src/api/domains/list_domains.rs
@@ -1,0 +1,112 @@
+use std::borrow::Cow;
+
+use crate::api::domains::DomainSummary;
+use crate::Endpoint;
+use serde::{Deserialize, Serialize};
+use typed_builder::TypedBuilder;
+
+/// List domains with pagination.
+///
+/// ```
+/// use postmark::api::domains::ListDomainsRequest;
+/// let req = ListDomainsRequest::builder()
+///   .count(50)
+///   .offset(0)
+///   .build();
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "PascalCase")]
+#[derive(TypedBuilder)]
+pub struct ListDomainsRequest {
+    /// Number of records to return per request. Max 500.
+    #[serde(skip)]
+    pub count: i64,
+    /// Number of records to skip.
+    #[serde(skip)]
+    pub offset: i64,
+}
+
+/// Response for the [`ListDomainsRequest`] endpoint.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ListDomainsResponse {
+    /// Total number of domains matching the query. May exceed the number returned in a single call.
+    pub total_count: i64,
+    /// List of domain summaries.
+    pub domains: Vec<DomainSummary>,
+}
+
+impl Endpoint for ListDomainsRequest {
+    type Request = ListDomainsRequest;
+    type Response = ListDomainsResponse;
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("/domains?count={}&offset={}", self.count, self.offset).into()
+    }
+
+    fn body(&self) -> &Self::Request {
+        self
+    }
+
+    fn method(&self) -> http::Method {
+        http::Method::GET
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httptest::matchers::request;
+    use httptest::{responders::*, Expectation, Server};
+    use serde_json::json;
+
+    use crate::reqwest::PostmarkClient;
+    use crate::Query;
+
+    use super::*;
+
+    #[tokio::test]
+    pub async fn list_domains() {
+        let server = Server::run();
+
+        server.expect(
+            Expectation::matching(request::method_path("GET", "/domains"))
+                .respond_with(json_encoded(json!({
+                    "TotalCount": 2,
+                    "Domains": [
+                        {
+                            "Name": "postmarkapp.com",
+                            "SPFVerified": true,
+                            "DKIMVerified": true,
+                            "WeakDKIM": false,
+                            "ReturnPathDomainVerified": false,
+                            "ID": 36735
+                        },
+                        {
+                            "Name": "example.com",
+                            "SPFVerified": true,
+                            "DKIMVerified": true,
+                            "WeakDKIM": false,
+                            "ReturnPathDomainVerified": true,
+                            "ID": 81605
+                        }
+                    ]
+                }))),
+        );
+
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+
+        let req = ListDomainsRequest::builder().count(50).offset(0).build();
+
+        let resp = req
+            .execute(&client)
+            .await
+            .expect("Should get a response and be able to json decode it");
+
+        assert_eq!(resp.total_count, 2);
+        assert_eq!(resp.domains.len(), 2);
+        assert_eq!(resp.domains[0].name, "postmarkapp.com");
+        assert_eq!(resp.domains[0].id, 36735);
+    }
+}

--- a/src/api/domains/list_domains.rs
+++ b/src/api/domains/list_domains.rs
@@ -20,10 +20,10 @@ use typed_builder::TypedBuilder;
 pub struct ListDomainsRequest {
     /// Number of records to return per request. Max 500.
     #[serde(skip)]
-    pub count: i64,
+    pub count: isize,
     /// Number of records to skip.
     #[serde(skip)]
-    pub offset: i64,
+    pub offset: isize,
 }
 
 /// Response for the [`ListDomainsRequest`] endpoint.
@@ -31,7 +31,7 @@ pub struct ListDomainsRequest {
 #[serde(rename_all = "PascalCase")]
 pub struct ListDomainsResponse {
     /// Total number of domains matching the query. May exceed the number returned in a single call.
-    pub total_count: i64,
+    pub total_count: isize,
     /// List of domain summaries.
     pub domains: Vec<DomainSummary>,
 }

--- a/src/api/domains/rotate_dkim.rs
+++ b/src/api/domains/rotate_dkim.rs
@@ -1,0 +1,132 @@
+use std::borrow::Cow;
+
+use crate::api::domains::DkimUpdateStatus;
+use crate::Endpoint;
+use serde::{Deserialize, Serialize};
+use typed_builder::TypedBuilder;
+
+/// Request rotation of DKIM keys for the specified domain.
+///
+/// ```
+/// use postmark::api::domains::RotateDkimRequest;
+/// let req = RotateDkimRequest::builder()
+///   .domain_id(36735)
+///   .build();
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "PascalCase")]
+#[derive(TypedBuilder)]
+pub struct RotateDkimRequest {
+    /// Unique ID of the domain whose DKIM keys should be rotated.
+    #[serde(skip)]
+    pub domain_id: i64,
+}
+
+/// Response for the [`RotateDkimRequest`] endpoint.
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct RotateDkimResponse {
+    /// Domain name.
+    pub name: String,
+    /// Whether DKIM has ever been verified for the domain.
+    #[serde(rename = "DKIMVerified")]
+    pub dkim_verified: bool,
+    /// Whether DKIM is using a strength weaker than 1024 bit.
+    #[serde(rename = "WeakDKIM")]
+    pub weak_dkim: bool,
+    /// DNS TXT host being used to validate messages sent in.
+    #[serde(rename = "DKIMHost")]
+    pub dkim_host: String,
+    /// DNS TXT value being used to validate messages sent in.
+    #[serde(rename = "DKIMTextValue")]
+    pub dkim_text_value: String,
+    /// Pending DKIM DNS TXT host awaiting setup and confirmation at your registrar or DNS host.
+    #[serde(rename = "DKIMPendingHost")]
+    pub dkim_pending_host: String,
+    /// Pending DKIM DNS TXT value awaiting confirmation at your registrar or DNS host.
+    #[serde(rename = "DKIMPendingTextValue")]
+    pub dkim_pending_text_value: String,
+    /// The old DKIM host that Postmark has revoked after a new DKIM was confirmed.
+    #[serde(rename = "DKIMRevokedHost")]
+    pub dkim_revoked_host: String,
+    /// The old DKIM DNS TXT value that will soon be removed from the Postmark system.
+    #[serde(rename = "DKIMRevokedTextValue")]
+    pub dkim_revoked_text_value: String,
+    /// Whether you may safely delete the old revoked DKIM DNS TXT records.
+    #[serde(rename = "SafeToRemoveRevokedKeyFromDNS")]
+    pub safe_to_remove_revoked_key_from_dns: bool,
+    /// DKIM update status.
+    #[serde(rename = "DKIMUpdateStatus")]
+    pub dkim_update_status: DkimUpdateStatus,
+    /// Unique ID of the domain.
+    #[serde(rename = "ID")]
+    pub id: i64,
+}
+
+impl Endpoint for RotateDkimRequest {
+    type Request = RotateDkimRequest;
+    type Response = RotateDkimResponse;
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("/domains/{}/rotateDKIM", self.domain_id).into()
+    }
+
+    fn body(&self) -> &Self::Request {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httptest::matchers::request;
+    use httptest::{responders::*, Expectation, Server};
+    use serde_json::json;
+
+    use crate::reqwest::PostmarkClient;
+    use crate::Query;
+
+    use super::*;
+
+    const DOMAIN_ID: i64 = 36735;
+
+    #[tokio::test]
+    pub async fn rotate_dkim() {
+        let server = Server::run();
+
+        server.expect(
+            Expectation::matching(request::method_path(
+                "POST",
+                format!("/domains/{DOMAIN_ID}/rotateDKIM"),
+            ))
+            .respond_with(json_encoded(json!({
+                "Name": "postmarkapp.com",
+                "DKIMVerified": false,
+                "WeakDKIM": false,
+                "DKIMHost": "jan2013pm._domainkey.postmarkapp.com",
+                "DKIMTextValue": "k=rsa;p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDJ...",
+                "DKIMPendingHost": "20131031155228pm._domainkey.postmarkapp.com",
+                "DKIMPendingTextValue": "k=rsa;p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCFn...",
+                "DKIMRevokedHost": "",
+                "DKIMRevokedTextValue": "",
+                "SafeToRemoveRevokedKeyFromDNS": false,
+                "DKIMUpdateStatus": "Pending",
+                "ID": 36735
+            }))),
+        );
+
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+
+        let req = RotateDkimRequest::builder().domain_id(DOMAIN_ID).build();
+
+        let resp = req
+            .execute(&client)
+            .await
+            .expect("Should get a response and be able to json decode it");
+
+        assert_eq!(resp.name, "postmarkapp.com");
+        assert_eq!(resp.dkim_update_status, DkimUpdateStatus::Pending);
+        assert_eq!(resp.id, DOMAIN_ID);
+    }
+}

--- a/src/api/domains/rotate_dkim.rs
+++ b/src/api/domains/rotate_dkim.rs
@@ -68,7 +68,7 @@ impl Endpoint for RotateDkimRequest {
     type Response = RotateDkimResponse;
 
     fn endpoint(&self) -> Cow<'static, str> {
-        format!("/domains/{}/rotateDKIM", self.domain_id).into()
+        format!("/domains/{}/rotatedkim", self.domain_id).into()
     }
 
     fn body(&self) -> &Self::Request {
@@ -96,7 +96,7 @@ mod tests {
         server.expect(
             Expectation::matching(request::method_path(
                 "POST",
-                format!("/domains/{DOMAIN_ID}/rotateDKIM"),
+                format!("/domains/{DOMAIN_ID}/rotatedkim"),
             ))
             .respond_with(json_encoded(json!({
                 "Name": "postmarkapp.com",

--- a/src/api/domains/rotate_dkim.rs
+++ b/src/api/domains/rotate_dkim.rs
@@ -19,7 +19,7 @@ use typed_builder::TypedBuilder;
 pub struct RotateDkimRequest {
     /// Unique ID of the domain whose DKIM keys should be rotated.
     #[serde(skip)]
-    pub domain_id: i64,
+    pub domain_id: isize,
 }
 
 /// Response for the [`RotateDkimRequest`] endpoint.
@@ -60,7 +60,7 @@ pub struct RotateDkimResponse {
     pub dkim_update_status: DkimUpdateStatus,
     /// Unique ID of the domain.
     #[serde(rename = "ID")]
-    pub id: i64,
+    pub id: isize,
 }
 
 impl Endpoint for RotateDkimRequest {
@@ -87,7 +87,7 @@ mod tests {
 
     use super::*;
 
-    const DOMAIN_ID: i64 = 36735;
+    const DOMAIN_ID: isize = 36735;
 
     #[tokio::test]
     pub async fn rotate_dkim() {

--- a/src/api/domains/verify_dkim.rs
+++ b/src/api/domains/verify_dkim.rs
@@ -1,0 +1,100 @@
+use std::borrow::Cow;
+
+use crate::api::domains::DomainDetails;
+use crate::Endpoint;
+use serde::Serialize;
+use typed_builder::TypedBuilder;
+
+/// Verify DKIM keys for the specified domain.
+///
+/// ```
+/// use postmark::api::domains::VerifyDkimRequest;
+/// let req = VerifyDkimRequest::builder()
+///   .domain_id(36735)
+///   .build();
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "PascalCase")]
+#[derive(TypedBuilder)]
+pub struct VerifyDkimRequest {
+    /// Unique ID of the domain whose DKIM keys should be verified.
+    #[serde(skip)]
+    pub domain_id: i64,
+}
+
+impl Endpoint for VerifyDkimRequest {
+    type Request = VerifyDkimRequest;
+    type Response = DomainDetails;
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("/domains/{}/verifyDkim", self.domain_id).into()
+    }
+
+    fn body(&self) -> &Self::Request {
+        self
+    }
+
+    fn method(&self) -> http::Method {
+        http::Method::PUT
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httptest::matchers::request;
+    use httptest::{responders::*, Expectation, Server};
+    use serde_json::json;
+
+    use crate::reqwest::PostmarkClient;
+    use crate::Query;
+
+    use super::*;
+
+    const DOMAIN_ID: i64 = 36735;
+
+    #[tokio::test]
+    pub async fn verify_dkim() {
+        let server = Server::run();
+
+        server.expect(
+            Expectation::matching(request::method_path(
+                "PUT",
+                format!("/domains/{DOMAIN_ID}/verifyDkim"),
+            ))
+            .respond_with(json_encoded(json!({
+                "Name": "postmarkapp.com",
+                "SPFVerified": true,
+                "SPFHost": "postmarkapp.com",
+                "SPFTextValue": "v=spf1 a mx include:spf.mtasv.net ~all",
+                "DKIMVerified": false,
+                "WeakDKIM": false,
+                "DKIMHost": "jan2013pm._domainkey.postmarkapp.com",
+                "DKIMTextValue": "k=rsa;p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDJ...",
+                "DKIMPendingHost": "20131031155228pm._domainkey.postmarkapp.com",
+                "DKIMPendingTextValue": "k=rsa;p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCFn...",
+                "DKIMRevokedHost": "",
+                "DKIMRevokedTextValue": "",
+                "SafeToRemoveRevokedKeyFromDNS": false,
+                "DKIMUpdateStatus": "Pending",
+                "ReturnPathDomain": "pm-bounces.postmarkapp.com",
+                "ReturnPathDomainVerified": false,
+                "ReturnPathDomainCNAMEValue": "pm.mtasv.net",
+                "ID": 36735
+            }))),
+        );
+
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+
+        let req = VerifyDkimRequest::builder().domain_id(DOMAIN_ID).build();
+
+        let resp = req
+            .execute(&client)
+            .await
+            .expect("Should get a response and be able to json decode it");
+
+        assert_eq!(resp.name, "postmarkapp.com");
+        assert_eq!(resp.id, DOMAIN_ID);
+    }
+}

--- a/src/api/domains/verify_dkim.rs
+++ b/src/api/domains/verify_dkim.rs
@@ -19,7 +19,7 @@ use typed_builder::TypedBuilder;
 pub struct VerifyDkimRequest {
     /// Unique ID of the domain whose DKIM keys should be verified.
     #[serde(skip)]
-    pub domain_id: i64,
+    pub domain_id: isize,
 }
 
 impl Endpoint for VerifyDkimRequest {
@@ -50,7 +50,7 @@ mod tests {
 
     use super::*;
 
-    const DOMAIN_ID: i64 = 36735;
+    const DOMAIN_ID: isize = 36735;
 
     #[tokio::test]
     pub async fn verify_dkim() {

--- a/src/api/domains/verify_return_path.rs
+++ b/src/api/domains/verify_return_path.rs
@@ -1,0 +1,102 @@
+use std::borrow::Cow;
+
+use crate::api::domains::DomainDetails;
+use crate::Endpoint;
+use serde::Serialize;
+use typed_builder::TypedBuilder;
+
+/// Verify Return-Path DNS record for the specified domain.
+///
+/// ```
+/// use postmark::api::domains::VerifyReturnPathRequest;
+/// let req = VerifyReturnPathRequest::builder()
+///   .domain_id(36735)
+///   .build();
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "PascalCase")]
+#[derive(TypedBuilder)]
+pub struct VerifyReturnPathRequest {
+    /// Unique ID of the domain whose Return-Path DNS record should be verified.
+    #[serde(skip)]
+    pub domain_id: i64,
+}
+
+impl Endpoint for VerifyReturnPathRequest {
+    type Request = VerifyReturnPathRequest;
+    type Response = DomainDetails;
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("/domains/{}/verifyReturnPath", self.domain_id).into()
+    }
+
+    fn body(&self) -> &Self::Request {
+        self
+    }
+
+    fn method(&self) -> http::Method {
+        http::Method::PUT
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httptest::matchers::request;
+    use httptest::{responders::*, Expectation, Server};
+    use serde_json::json;
+
+    use crate::reqwest::PostmarkClient;
+    use crate::Query;
+
+    use super::*;
+
+    const DOMAIN_ID: i64 = 36735;
+
+    #[tokio::test]
+    pub async fn verify_return_path() {
+        let server = Server::run();
+
+        server.expect(
+            Expectation::matching(request::method_path(
+                "PUT",
+                format!("/domains/{DOMAIN_ID}/verifyReturnPath"),
+            ))
+            .respond_with(json_encoded(json!({
+                "Name": "postmarkapp.com",
+                "SPFVerified": true,
+                "SPFHost": "postmarkapp.com",
+                "SPFTextValue": "v=spf1 a mx include:spf.mtasv.net ~all",
+                "DKIMVerified": false,
+                "WeakDKIM": false,
+                "DKIMHost": "jan2013pm._domainkey.postmarkapp.com",
+                "DKIMTextValue": "k=rsa;p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDJ...",
+                "DKIMPendingHost": "20131031155228pm._domainkey.postmarkapp.com",
+                "DKIMPendingTextValue": "k=rsa;p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCFn...",
+                "DKIMRevokedHost": "",
+                "DKIMRevokedTextValue": "",
+                "SafeToRemoveRevokedKeyFromDNS": false,
+                "DKIMUpdateStatus": "Pending",
+                "ReturnPathDomain": "pm-bounces.postmarkapp.com",
+                "ReturnPathDomainVerified": false,
+                "ReturnPathDomainCNAMEValue": "pm.mtasv.net",
+                "ID": 36735
+            }))),
+        );
+
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+
+        let req = VerifyReturnPathRequest::builder()
+            .domain_id(DOMAIN_ID)
+            .build();
+
+        let resp = req
+            .execute(&client)
+            .await
+            .expect("Should get a response and be able to json decode it");
+
+        assert_eq!(resp.name, "postmarkapp.com");
+        assert_eq!(resp.id, DOMAIN_ID);
+    }
+}

--- a/src/api/domains/verify_return_path.rs
+++ b/src/api/domains/verify_return_path.rs
@@ -19,7 +19,7 @@ use typed_builder::TypedBuilder;
 pub struct VerifyReturnPathRequest {
     /// Unique ID of the domain whose Return-Path DNS record should be verified.
     #[serde(skip)]
-    pub domain_id: i64,
+    pub domain_id: isize,
 }
 
 impl Endpoint for VerifyReturnPathRequest {
@@ -50,7 +50,7 @@ mod tests {
 
     use super::*;
 
-    const DOMAIN_ID: i64 = 36735;
+    const DOMAIN_ID: isize = 36735;
 
     #[tokio::test]
     pub async fn verify_return_path() {

--- a/src/api/domains/verify_spf.rs
+++ b/src/api/domains/verify_spf.rs
@@ -19,7 +19,7 @@ use typed_builder::TypedBuilder;
 pub struct VerifySpfRequest {
     /// Unique ID of the domain whose SPF record should be verified.
     #[serde(skip)]
-    pub domain_id: i64,
+    pub domain_id: isize,
 }
 
 impl Endpoint for VerifySpfRequest {
@@ -50,7 +50,7 @@ mod tests {
 
     use super::*;
 
-    const DOMAIN_ID: i64 = 36735;
+    const DOMAIN_ID: isize = 36735;
 
     #[tokio::test]
     pub async fn verify_spf() {

--- a/src/api/domains/verify_spf.rs
+++ b/src/api/domains/verify_spf.rs
@@ -1,0 +1,101 @@
+use std::borrow::Cow;
+
+use crate::api::domains::DomainDetails;
+use crate::Endpoint;
+use serde::Serialize;
+use typed_builder::TypedBuilder;
+
+/// Verify SPF record for the specified domain.
+///
+/// ```
+/// use postmark::api::domains::VerifySpfRequest;
+/// let req = VerifySpfRequest::builder()
+///   .domain_id(36735)
+///   .build();
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "PascalCase")]
+#[derive(TypedBuilder)]
+pub struct VerifySpfRequest {
+    /// Unique ID of the domain whose SPF record should be verified.
+    #[serde(skip)]
+    pub domain_id: i64,
+}
+
+impl Endpoint for VerifySpfRequest {
+    type Request = VerifySpfRequest;
+    type Response = DomainDetails;
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("/domains/{}/verifySPF", self.domain_id).into()
+    }
+
+    fn body(&self) -> &Self::Request {
+        self
+    }
+
+    fn method(&self) -> http::Method {
+        http::Method::POST
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httptest::matchers::request;
+    use httptest::{responders::*, Expectation, Server};
+    use serde_json::json;
+
+    use crate::reqwest::PostmarkClient;
+    use crate::Query;
+
+    use super::*;
+
+    const DOMAIN_ID: i64 = 36735;
+
+    #[tokio::test]
+    pub async fn verify_spf() {
+        let server = Server::run();
+
+        server.expect(
+            Expectation::matching(request::method_path(
+                "POST",
+                format!("/domains/{DOMAIN_ID}/verifySPF"),
+            ))
+            .respond_with(json_encoded(json!({
+                "Name": "postmarkapp.com",
+                "SPFVerified": true,
+                "SPFHost": "postmarkapp.com",
+                "SPFTextValue": "v=spf1 a mx include:spf.mtasv.net ~all",
+                "DKIMVerified": false,
+                "WeakDKIM": false,
+                "DKIMHost": "jan2013pm._domainkey.postmarkapp.com",
+                "DKIMTextValue": "k=rsa;p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDJ...",
+                "DKIMPendingHost": "20131031155228pm._domainkey.postmarkapp.com",
+                "DKIMPendingTextValue": "k=rsa;p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCFn...",
+                "DKIMRevokedHost": "",
+                "DKIMRevokedTextValue": "",
+                "SafeToRemoveRevokedKeyFromDNS": false,
+                "DKIMUpdateStatus": "Pending",
+                "ReturnPathDomain": "pm-bounces.postmarkapp.com",
+                "ReturnPathDomainVerified": false,
+                "ReturnPathDomainCNAMEValue": "pm.mtasv.net",
+                "ID": 36735
+            }))),
+        );
+
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+
+        let req = VerifySpfRequest::builder().domain_id(DOMAIN_ID).build();
+
+        let resp = req
+            .execute(&client)
+            .await
+            .expect("Should get a response and be able to json decode it");
+
+        assert_eq!(resp.name, "postmarkapp.com");
+        assert_eq!(resp.spf_verified, true);
+        assert_eq!(resp.id, DOMAIN_ID);
+    }
+}

--- a/src/api/domains/verify_spf.rs
+++ b/src/api/domains/verify_spf.rs
@@ -1,8 +1,7 @@
 use std::borrow::Cow;
 
-use crate::api::domains::DomainDetails;
 use crate::Endpoint;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder;
 
 /// Verify SPF record for the specified domain.
@@ -22,12 +21,27 @@ pub struct VerifySpfRequest {
     pub domain_id: isize,
 }
 
+/// Response for the [`VerifySpfRequest`] endpoint.
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct VerifySpfResponse {
+    /// Host name used for the SPF configuration.
+    #[serde(rename = "SPFHost")]
+    pub spf_host: String,
+    /// Whether SPF DNS text record has been setup correctly.
+    #[serde(rename = "SPFVerified")]
+    pub spf_verified: bool,
+    /// Value that can be optionally set up with your DNS host for SPF verification.
+    #[serde(rename = "SPFTextValue")]
+    pub spf_text_value: String,
+}
+
 impl Endpoint for VerifySpfRequest {
     type Request = VerifySpfRequest;
-    type Response = DomainDetails;
+    type Response = VerifySpfResponse;
 
     fn endpoint(&self) -> Cow<'static, str> {
-        format!("/domains/{}/verifySPF", self.domain_id).into()
+        format!("/domains/{}/verifyspf", self.domain_id).into()
     }
 
     fn body(&self) -> &Self::Request {
@@ -59,27 +73,12 @@ mod tests {
         server.expect(
             Expectation::matching(request::method_path(
                 "POST",
-                format!("/domains/{DOMAIN_ID}/verifySPF"),
+                format!("/domains/{DOMAIN_ID}/verifyspf"),
             ))
             .respond_with(json_encoded(json!({
-                "Name": "postmarkapp.com",
-                "SPFVerified": true,
                 "SPFHost": "postmarkapp.com",
+                "SPFVerified": true,
                 "SPFTextValue": "v=spf1 a mx include:spf.mtasv.net ~all",
-                "DKIMVerified": false,
-                "WeakDKIM": false,
-                "DKIMHost": "jan2013pm._domainkey.postmarkapp.com",
-                "DKIMTextValue": "k=rsa;p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDJ...",
-                "DKIMPendingHost": "20131031155228pm._domainkey.postmarkapp.com",
-                "DKIMPendingTextValue": "k=rsa;p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCFn...",
-                "DKIMRevokedHost": "",
-                "DKIMRevokedTextValue": "",
-                "SafeToRemoveRevokedKeyFromDNS": false,
-                "DKIMUpdateStatus": "Pending",
-                "ReturnPathDomain": "pm-bounces.postmarkapp.com",
-                "ReturnPathDomainVerified": false,
-                "ReturnPathDomainCNAMEValue": "pm.mtasv.net",
-                "ID": 36735
             }))),
         );
 
@@ -94,8 +93,7 @@ mod tests {
             .await
             .expect("Should get a response and be able to json decode it");
 
-        assert_eq!(resp.name, "postmarkapp.com");
-        assert_eq!(resp.spf_verified, true);
-        assert_eq!(resp.id, DOMAIN_ID);
+        assert!(resp.spf_verified);
+        assert_eq!(resp.spf_host, "postmarkapp.com");
     }
 }

--- a/src/api/email/send_email.rs
+++ b/src/api/email/send_email.rs
@@ -106,18 +106,13 @@ pub struct Attachment {
 }
 
 /// Activate link tracking for links in the HTML or Text bodies of this email.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub enum TrackLink {
+    #[default]
     None,
     HtmlAndText,
     HtmlOnly,
     TextOnly,
-}
-
-impl Default for TrackLink {
-    fn default() -> Self {
-        Self::None
-    }
 }
 
 /// Response for the [`SendEmailRequest`] Endpoint.

--- a/src/api/message_streams/delete_suppression.rs
+++ b/src/api/message_streams/delete_suppression.rs
@@ -111,7 +111,7 @@ mod tests {
             ]))
             .build();
 
-        print!("{}\n", req.endpoint());
+        println!("{}", req.endpoint());
 
         req.execute(&client)
             .await

--- a/src/api/message_streams/get_suppressions.rs
+++ b/src/api/message_streams/get_suppressions.rs
@@ -100,7 +100,7 @@ mod tests {
             .stream_id(StreamIdOrName::StreamId(String::from(STREAM_ID)))
             .build();
 
-        print!("{}\n", req.endpoint());
+        println!("{}", req.endpoint());
 
         req.execute(&client)
             .await

--- a/src/api/server/get_server.rs
+++ b/src/api/server/get_server.rs
@@ -94,7 +94,7 @@ mod tests {
             .server_id(ServerIdOrName::ServerId(SERVER_ID))
             .build();
 
-        print!("{}\n", req.endpoint());
+        println!("{}", req.endpoint());
 
         req.execute(&client)
             .await

--- a/src/api/templates/delete_template.rs
+++ b/src/api/templates/delete_template.rs
@@ -86,7 +86,7 @@ mod tests {
             .id(TemplateIdOrAlias::TemplateId(12345))
             .build();
 
-        print!("{}\n", req.endpoint());
+        println!("{}", req.endpoint());
 
         req.execute(&client)
             .await
@@ -116,7 +116,7 @@ mod tests {
             .id(TemplateIdOrAlias::Alias(String::from(ALIAS)))
             .build();
 
-        print!("{}\n", req.endpoint());
+        println!("{}", req.endpoint());
 
         req.execute(&client)
             .await

--- a/src/api/templates/get_template.rs
+++ b/src/api/templates/get_template.rs
@@ -115,7 +115,7 @@ mod tests {
             .id(TemplateIdOrAlias::TemplateId(12345))
             .build();
 
-        print!("{}\n", req.endpoint());
+        println!("{}", req.endpoint());
 
         req.execute(&client)
             .await
@@ -150,7 +150,7 @@ mod tests {
             .id(TemplateIdOrAlias::Alias(String::from(ALIAS)))
             .build();
 
-        print!("{}\n", req.endpoint());
+        println!("{}", req.endpoint());
 
         req.execute(&client)
             .await


### PR DESCRIPTION
## Summary
- Merged existing Domains feature work from PR #45 into integration branch with merge commits to preserve original commit SHAs/authorship.
- Fixed endpoint path casing for Domains verify SPF (`verifyspf`) and rotate DKIM (`rotatedkim`) to match Postmark API.
- Changed SPF verify endpoint response model to SPF-specific fields and updated tests accordingly.

## Validation
- `cargo test` (pass)
- `cargo clippy --all-targets` (existing warnings only)