### PR TITLE
add missing postmark api sections + coverage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,34 @@ async fn send_email(){
 }
 ```
 
+# API coverage
+
+Detailed endpoint matrix and examples:
+
+- `docs/api/postmark-endpoints.md`
+- `docs/api/examples/`
+- `docs/api/compatibility.md`
+
+Current high-level status:
+
+| Section | Status |
+|---|---|
+| Email | implemented |
+| Bulk | implemented |
+| Bounce | implemented |
+| Templates | implemented |
+| Server | implemented |
+| Servers | implemented |
+| Message Streams | implemented |
+| Domains | implemented |
+| Sender Signatures | implemented (non-deprecated) |
+| Stats | implemented |
+| Triggers: Inbound rules | implemented |
+| Webhooks | implemented |
+| Suppressions | implemented |
+| Data Removal | implemented |
+| Messages | not implemented |
+
 # Releasing a new version
 
 Prerequisite:

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,10 @@
+# API docs index
+
+- Endpoint matrix: `docs/api/postmark-endpoints.md`
+- Compatibility notes: `docs/api/compatibility.md`
+- Coverage update workflow: `docs/api/updating-endpoint-coverage.md`
+- Examples:
+  - `docs/api/examples/bulk.md`
+  - `docs/api/examples/signatures.md`
+  - `docs/api/examples/stats.md`
+  - `docs/api/examples/triggers-data-removal.md`

--- a/docs/api/compatibility.md
+++ b/docs/api/compatibility.md
@@ -1,0 +1,24 @@
+# API compatibility notes
+
+## Token model
+
+- Endpoints that require `X-Postmark-Server-Token` should be used with `PostmarkClient.server_token`.
+- Endpoints that require `X-Postmark-Account-Token` should be used with `PostmarkClient.account_token`.
+- The client can carry both; endpoint docs in `docs/api/postmark-endpoints.md` show expected token type.
+
+## Deprecated endpoints policy
+
+- Sender Signature deprecated endpoints are intentionally excluded:
+  - `POST /senders/{id}/verifyspf`
+  - `POST /senders/{id}/requestnewdkim`
+- Preferred replacement for DKIM operations is Domains API (`/domains/{id}/rotatedkim`).
+
+## Field naming and casing
+
+- API payloads are modeled with Postmark PascalCase keys through serde renames.
+- Paths are matched to docs exactly (including lowercase segments like `verifyspf`, `rotatedkim`).
+
+## Forward-compat strategy
+
+- Unknown fields from Postmark are ignored by serde by default.
+- Dynamic-key stats endpoints (`emailclients`, `browserfamilies`) are represented with a flattened map payload in response structs.

--- a/docs/api/examples/bulk.md
+++ b/docs/api/examples/bulk.md
@@ -1,0 +1,33 @@
+# Bulk API examples
+
+```rust
+use postmark::api::bulk::{BulkMessage, GetBulkStatusRequest, SendBulkEmailRequest};
+use postmark::reqwest::PostmarkClient;
+use postmark::Query;
+
+async fn send_and_check_bulk() {
+    let client = PostmarkClient::builder()
+        .server_token("<server-token>")
+        .build();
+
+    let send_req = SendBulkEmailRequest::builder()
+        .from("sender@example.com".to_string())
+        .subject("Hello {{FirstName}}")
+        .text_body("Hi {{FirstName}}")
+        .message_stream("broadcast")
+        .messages(vec![BulkMessage {
+            to: "receiver@example.com".to_string(),
+            ..Default::default()
+        }])
+        .build();
+
+    let accepted = send_req.execute(&client).await.unwrap();
+
+    let status_req = GetBulkStatusRequest::builder()
+        .bulk_request_id(accepted.id)
+        .build();
+
+    let status = status_req.execute(&client).await.unwrap();
+    assert!(status.percentage_completed >= 0.0);
+}
+```

--- a/docs/api/examples/signatures.md
+++ b/docs/api/examples/signatures.md
@@ -1,0 +1,25 @@
+# Sender signatures examples
+
+```rust
+use postmark::api::signatures::{CreateSignatureRequest, ListSignaturesRequest};
+use postmark::reqwest::PostmarkClient;
+use postmark::Query;
+
+async fn signatures_examples() {
+    let client = PostmarkClient::builder()
+        .account_token("<account-token>")
+        .build();
+
+    let create_req = CreateSignatureRequest::builder()
+        .from_email("john@example.com".to_string())
+        .name("John".to_string())
+        .build();
+
+    let created = create_req.execute(&client).await.unwrap();
+
+    let list_req = ListSignaturesRequest::builder().count(50).offset(0).build();
+    let list = list_req.execute(&client).await.unwrap();
+
+    assert!(list.sender_signatures.iter().any(|s| s.id == created.id));
+}
+```

--- a/docs/api/examples/stats.md
+++ b/docs/api/examples/stats.md
@@ -1,0 +1,25 @@
+# Stats API examples
+
+```rust
+use postmark::api::stats::{GetOutboundOverviewRequest, StatsQuery};
+use postmark::reqwest::PostmarkClient;
+use postmark::Query;
+
+async fn get_overview() {
+    let client = PostmarkClient::builder()
+        .server_token("<server-token>")
+        .build();
+
+    let req = GetOutboundOverviewRequest::builder()
+        .query(StatsQuery {
+            fromdate: Some("2026-01-01".to_string()),
+            todate: Some("2026-01-31".to_string()),
+            messagestream: Some("outbound".to_string()),
+            ..Default::default()
+        })
+        .build();
+
+    let overview = req.execute(&client).await.unwrap();
+    assert!(overview.sent >= 0);
+}
+```

--- a/docs/api/examples/triggers-data-removal.md
+++ b/docs/api/examples/triggers-data-removal.md
@@ -1,0 +1,59 @@
+# Triggers and Data Removal examples
+
+```rust
+use postmark::api::data_removal::{CreateDataRemovalRequest, GetDataRemovalStatusRequest};
+use postmark::api::triggers::{
+    CreateInboundRuleTriggerRequest, DeleteInboundRuleTriggerRequest, ListInboundRuleTriggersRequest,
+};
+use postmark::reqwest::PostmarkClient;
+use postmark::Query;
+
+async fn trigger_examples() {
+    let server_client = PostmarkClient::builder()
+        .server_token("<server-token>")
+        .build();
+
+    let create = CreateInboundRuleTriggerRequest::builder()
+        .rule("blocked@example.com".to_string())
+        .build()
+        .execute(&server_client)
+        .await
+        .unwrap();
+
+    let _rules = ListInboundRuleTriggersRequest::builder()
+        .count(50)
+        .offset(0)
+        .build()
+        .execute(&server_client)
+        .await
+        .unwrap();
+
+    let _ = DeleteInboundRuleTriggerRequest::builder()
+        .trigger_id(create.id)
+        .build()
+        .execute(&server_client)
+        .await
+        .unwrap();
+}
+
+async fn data_removal_examples() {
+    let account_client = PostmarkClient::builder()
+        .account_token("<account-token>")
+        .build();
+
+    let req = CreateDataRemovalRequest::builder()
+        .requested_by("owner@example.com".to_string())
+        .requested_for("recipient@example.com".to_string())
+        .notify_when_completed(true)
+        .build();
+
+    let created = req.execute(&account_client).await.unwrap();
+
+    let _status = GetDataRemovalStatusRequest::builder()
+        .data_removal_id(created.id)
+        .build()
+        .execute(&account_client)
+        .await
+        .unwrap();
+}
+```

--- a/docs/api/postmark-endpoints.md
+++ b/docs/api/postmark-endpoints.md
@@ -1,0 +1,148 @@
+# Postmark endpoint coverage
+
+Scope: endpoints represented in this crate.
+
+Legend:
+
+- `x` implemented
+- `-` not implemented
+- `deprecated` intentionally excluded
+
+## Email
+
+| Method | Path | Token | Status | Rust request type |
+|---|---|---|---|---|
+| POST | `/email` | server | x | `api::email::SendEmailRequest` |
+| POST | `/email/batch` | server | x | `api::email::SendEmailBatchRequest` |
+| POST | `/email/withTemplate` | server | x | `api::email::SendEmailWithTemplateRequest` |
+| POST | `/email/batchWithTemplates` | server | x | `api::email::SendEmailBatchWithTemplatesRequest` |
+
+## Bulk
+
+| Method | Path | Token | Status | Rust request type |
+|---|---|---|---|---|
+| POST | `/email/bulk` | server | x | `api::bulk::SendBulkEmailRequest` |
+| GET | `/email/bulk/{id}` | server | x | `api::bulk::GetBulkStatusRequest` |
+
+## Bounce
+
+| Method | Path | Token | Status | Rust request type |
+|---|---|---|---|---|
+| GET | `/deliverystats` | server | x | `api::bounce::GetDeliveryStatsRequest` |
+| GET | `/bounces` | server | x | `api::bounce::ListBouncesRequest` |
+| GET | `/bounces/{id}` | server | x | `api::bounce::GetBounceRequest` |
+| GET | `/bounces/{id}/dump` | server | x | `api::bounce::GetBounceDumpRequest` |
+| PUT | `/bounces/{id}/activate` | server | x | `api::bounce::ActivateBounceRequest` |
+
+## Templates
+
+| Method | Path | Token | Status | Rust request type |
+|---|---|---|---|---|
+| GET | `/templates/{id}` | server | x | `api::templates::GetTemplateRequest` |
+| POST | `/templates` | server | x | `api::templates::CreateTemplateRequest` |
+| PUT | `/templates/{id}` | server | x | `api::templates::EditTemplateRequest` |
+| GET | `/templates?count={count}&offset={offset}` | server | x | `api::templates::ListTemplatesRequest` |
+| DELETE | `/templates/{id}` | server | x | `api::templates::DeleteTemplateRequest` |
+| POST | `/templates/validate` | server | x | `api::templates::ValidateTemplateRequest` |
+| PUT | `/templates/push` | server | x | `api::templates::PushTemplatesRequest` |
+
+## Server / Servers
+
+| Method | Path | Token | Status | Rust request type |
+|---|---|---|---|---|
+| GET | `/server` | server | x | `api::server::GetCurrentServerRequest` |
+| PUT | `/server` | server | x | `api::server::EditServerRequest` |
+| GET | `/servers/{id}` | account | x | `api::server::GetServerRequest` |
+| POST | `/servers` | account | x | `api::server::CreateServerRequest` |
+| PUT | `/servers/{id}` | account | x | `api::server::EditServerByIdRequest` |
+| GET | `/servers?count={count}&offset={offset}` | account | x | `api::server::ListServersRequest` |
+| DELETE | `/servers/{id}` | account | x | `api::server::DeleteServerRequest` |
+
+## Message Streams / Suppressions
+
+| Method | Path | Token | Status | Rust request type |
+|---|---|---|---|---|
+| GET | `/message-streams` | server | x | `api::message_streams::ListMessageStreamsRequest` |
+| GET | `/message-streams/{id}` | server | x | `api::message_streams::GetMessageStreamRequest` |
+| PATCH | `/message-streams/{id}` | server | x | `api::message_streams::EditMessageStreamRequest` |
+| POST | `/message-streams` | server | x | `api::message_streams::CreateMessageStreamRequest` |
+| POST | `/message-streams/{id}/archive` | server | x | `api::message_streams::ArchiveMessageStreamRequest` |
+| POST | `/message-streams/{id}/unarchive` | server | x | `api::message_streams::UnarchiveMessageStreamRequest` |
+| GET | `/message-streams/{id}/suppressions/dump` | server | x | `api::message_streams::GetSuppressionsRequest` |
+| POST | `/message-streams/{id}/suppressions` | server | x | `api::message_streams::CreateSuppressionRequest` |
+| PUT | `/message-streams/{id}/suppressions/{email}` | server | x | `api::message_streams::DeleteSuppressionRequest` |
+
+## Domains
+
+| Method | Path | Token | Status | Rust request type |
+|---|---|---|---|---|
+| GET | `/domains` | account | x | `api::domains::ListDomainsRequest` |
+| GET | `/domains/{id}` | account | x | `api::domains::GetDomainRequest` |
+| POST | `/domains` | account | x | `api::domains::CreateDomainRequest` |
+| PUT | `/domains/{id}` | account | x | `api::domains::EditDomainRequest` |
+| DELETE | `/domains/{id}` | account | x | `api::domains::DeleteDomainRequest` |
+| POST | `/domains/{id}/verifyDKIM` | account | x | `api::domains::VerifyDkimRequest` |
+| POST | `/domains/{id}/verifyreturnpath` | account | x | `api::domains::VerifyReturnPathRequest` |
+| POST | `/domains/{id}/verifyspf` | account | x | `api::domains::VerifySpfRequest` |
+| POST | `/domains/{id}/rotatedkim` | account | x | `api::domains::RotateDkimRequest` |
+
+## Sender signatures
+
+| Method | Path | Token | Status | Rust request type |
+|---|---|---|---|---|
+| GET | `/senders?count={count}&offset={offset}` | account | x | `api::signatures::ListSignaturesRequest` |
+| GET | `/senders/{id}` | account | x | `api::signatures::GetSignatureRequest` |
+| POST | `/senders` | account | x | `api::signatures::CreateSignatureRequest` |
+| PUT | `/senders/{id}` | account | x | `api::signatures::EditSignatureRequest` |
+| DELETE | `/senders/{id}` | account | x | `api::signatures::DeleteSignatureRequest` |
+| POST | `/senders/{id}/resend` | account | x | `api::signatures::ResendSignatureConfirmationRequest` |
+| POST | `/senders/{id}/verifyspf` | account | deprecated | - |
+| POST | `/senders/{id}/requestnewdkim` | account | deprecated | - |
+
+## Stats
+
+| Method | Path | Token | Status | Rust request type |
+|---|---|---|---|---|
+| GET | `/stats/outbound` | server | x | `api::stats::GetOutboundOverviewRequest` |
+| GET | `/stats/outbound/sends` | server | x | `api::stats::GetSentCountsRequest` |
+| GET | `/stats/outbound/bounces` | server | x | `api::stats::GetBounceCountsRequest` |
+| GET | `/stats/outbound/spam` | server | x | `api::stats::GetSpamComplaintsRequest` |
+| GET | `/stats/outbound/tracked` | server | x | `api::stats::GetTrackedEmailCountsRequest` |
+| GET | `/stats/outbound/opens` | server | x | `api::stats::GetEmailOpenCountsRequest` |
+| GET | `/stats/outbound/opens/platforms` | server | x | `api::stats::GetEmailPlatformUsageRequest` |
+| GET | `/stats/outbound/opens/emailclients` | server | x | `api::stats::GetEmailClientUsageRequest` |
+| GET | `/stats/outbound/clicks` | server | x | `api::stats::GetClickCountsRequest` |
+| GET | `/stats/outbound/clicks/browserfamilies` | server | x | `api::stats::GetBrowserUsageRequest` |
+| GET | `/stats/outbound/clicks/platforms` | server | x | `api::stats::GetBrowserPlatformUsageRequest` |
+| GET | `/stats/outbound/clicks/location` | server | x | `api::stats::GetClickLocationRequest` |
+
+## Triggers: inbound rules
+
+| Method | Path | Token | Status | Rust request type |
+|---|---|---|---|---|
+| GET | `/triggers/inboundrules?count={count}&offset={offset}` | server | x | `api::triggers::ListInboundRuleTriggersRequest` |
+| POST | `/triggers/inboundrules` | server | x | `api::triggers::CreateInboundRuleTriggerRequest` |
+| DELETE | `/triggers/inboundrules/{id}` | server | x | `api::triggers::DeleteInboundRuleTriggerRequest` |
+
+## Webhooks
+
+| Method | Path | Token | Status | Rust request type |
+|---|---|---|---|---|
+| GET | `/webhooks` | server | x | `api::webhooks::ListWebhooksRequest` |
+| GET | `/webhooks/{id}` | server | x | `api::webhooks::GetWebhookRequest` |
+| POST | `/webhooks` | server | x | `api::webhooks::CreateWebhookRequest` |
+| PUT | `/webhooks/{id}` | server | x | `api::webhooks::EditWebhookRequest` |
+| DELETE | `/webhooks/{id}` | server | x | `api::webhooks::DeleteWebhookRequest` |
+
+## Data removal
+
+| Method | Path | Token | Status | Rust request type |
+|---|---|---|---|---|
+| POST | `/data-removals` | account | x | `api::data_removal::CreateDataRemovalRequest` |
+| GET | `/data-removals/{id}` | account | x | `api::data_removal::GetDataRemovalStatusRequest` |
+
+## Missing section
+
+| Section | Status |
+|---|---|
+| Messages API | not implemented |

--- a/docs/api/updating-endpoint-coverage.md
+++ b/docs/api/updating-endpoint-coverage.md
@@ -1,0 +1,23 @@
+# Updating endpoint coverage
+
+Use this flow when Postmark docs change.
+
+1. Compare sections in Postmark API reference against `docs/api/postmark-endpoints.md`.
+2. For every missing endpoint, add one endpoint file under the section module.
+3. Add re-export in section mod file and `src/api.rs` if it is a new section.
+4. Add tests per endpoint:
+   - method/path matcher test
+   - response decode test
+   - request serialization/query assertion (when relevant)
+5. Run:
+   - `cargo fmt`
+   - `cargo test`
+   - `cargo clippy --all-targets`
+6. Update endpoint matrix and examples in docs.
+
+## Review checklist
+
+- path casing matches docs exactly
+- token type documented (server/account)
+- deprecated endpoint policy respected
+- all new modules exported publicly

--- a/src/api.rs
+++ b/src/api.rs
@@ -8,11 +8,16 @@
 use serde::{Deserialize, Serialize};
 
 pub mod bounce;
+pub mod bulk;
+pub mod data_removal;
 pub mod domains;
 pub mod email;
 pub mod message_streams;
 pub mod server;
+pub mod signatures;
+pub mod stats;
 pub mod templates;
+pub mod triggers;
 pub mod webhooks;
 
 /// The body of a email message

--- a/src/api/bulk.rs
+++ b/src/api/bulk.rs
@@ -1,0 +1,7 @@
+//! Bulk email API endpoints.
+
+mod get_bulk_status;
+mod send_bulk;
+
+pub use get_bulk_status::*;
+pub use send_bulk::*;

--- a/src/api/bulk/get_bulk_status.rs
+++ b/src/api/bulk/get_bulk_status.rs
@@ -1,0 +1,82 @@
+use std::borrow::Cow;
+
+use crate::Endpoint;
+use serde::{Deserialize, Serialize};
+use typed_builder::TypedBuilder;
+
+#[derive(Debug, Clone, PartialEq, Serialize, TypedBuilder)]
+#[serde(rename_all = "PascalCase")]
+pub struct GetBulkStatusRequest {
+    #[serde(skip)]
+    pub bulk_request_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct GetBulkStatusResponse {
+    #[serde(alias = "Id", rename = "ID")]
+    pub id: String,
+    pub submitted_at: String,
+    pub total_messages: isize,
+    pub percentage_completed: f64,
+    pub status: String,
+    pub subject: Option<String>,
+}
+
+impl Endpoint for GetBulkStatusRequest {
+    type Request = GetBulkStatusRequest;
+    type Response = GetBulkStatusResponse;
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("/email/bulk/{}", self.bulk_request_id).into()
+    }
+
+    fn body(&self) -> &Self::Request {
+        self
+    }
+
+    fn method(&self) -> http::Method {
+        http::Method::GET
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httptest::matchers::request;
+    use httptest::{responders::*, Expectation, Server};
+    use serde_json::json;
+
+    use crate::reqwest::PostmarkClient;
+    use crate::Query;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn get_bulk_status() {
+        let server = Server::run();
+        server.expect(
+            Expectation::matching(request::method_path(
+                "GET",
+                "/email/bulk/dc5e5d98-c073-4c97-8ee5-f897dfd28b47",
+            ))
+            .respond_with(json_encoded(json!({
+                "Id": "dc5e5d98-c073-4c97-8ee5-f897dfd28b47",
+                "SubmittedAt": "2024-07-22T15:39:49.3723691Z",
+                "TotalMessages": 1,
+                "PercentageCompleted": 1,
+                "Status": "Completed",
+                "Subject": "Hello"
+            }))),
+        );
+
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+
+        let req = GetBulkStatusRequest::builder()
+            .bulk_request_id("dc5e5d98-c073-4c97-8ee5-f897dfd28b47".to_string())
+            .build();
+        let resp = req.execute(&client).await.expect("json decode");
+        assert_eq!(resp.status, "Completed");
+    }
+}

--- a/src/api/bulk/send_bulk.rs
+++ b/src/api/bulk/send_bulk.rs
@@ -1,0 +1,141 @@
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+use crate::api::email::{Attachment, Header, TrackLink};
+use crate::Endpoint;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use typed_builder::TypedBuilder;
+
+#[derive(Debug, Clone, PartialEq, Serialize, TypedBuilder)]
+#[serde(rename_all = "PascalCase")]
+pub struct SendBulkEmailRequest {
+    pub from: String,
+    pub messages: Vec<BulkMessage>,
+    #[builder(default, setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reply_to: Option<String>,
+    #[builder(default, setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subject: Option<String>,
+    #[builder(default, setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub html_body: Option<String>,
+    #[builder(default, setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_body: Option<String>,
+    #[builder(default, setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub template_id: Option<isize>,
+    #[builder(default, setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub template_alias: Option<String>,
+    #[builder(default, setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inline_css: Option<bool>,
+    #[builder(default, setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tag: Option<String>,
+    #[builder(default, setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HashMap<String, String>>,
+    #[builder(default, setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message_stream: Option<String>,
+    #[builder(default, setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub track_opens: Option<bool>,
+    #[builder(default, setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub track_links: Option<TrackLink>,
+    #[builder(default, setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attachments: Option<Vec<Attachment>>,
+    #[builder(default, setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub headers: Option<Vec<Header>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct BulkMessage {
+    pub to: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cc: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bcc: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub template_model: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HashMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub headers: Option<Vec<Header>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct SendBulkEmailResponse {
+    #[serde(rename = "ID")]
+    pub id: String,
+    pub status: String,
+    pub submitted_at: String,
+}
+
+impl Endpoint for SendBulkEmailRequest {
+    type Request = SendBulkEmailRequest;
+    type Response = SendBulkEmailResponse;
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        "/email/bulk".into()
+    }
+
+    fn body(&self) -> &Self::Request {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httptest::matchers::request;
+    use httptest::{responders::*, Expectation, Server};
+    use serde_json::json;
+
+    use crate::reqwest::PostmarkClient;
+    use crate::Query;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn send_bulk_email() {
+        let server = Server::run();
+
+        server.expect(
+            Expectation::matching(request::method_path("POST", "/email/bulk")).respond_with(
+                json_encoded(json!({
+                    "ID": "f24af63c-533d-4b7a-ad65-4a7b3202d3a7",
+                    "Status": "Accepted",
+                    "SubmittedAt": "2024-03-17T07:25:01.4178645-05:00"
+                })),
+            ),
+        );
+
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+
+        let req = SendBulkEmailRequest::builder()
+            .from("sender@example.com".to_string())
+            .subject("This is a bulk email for {{FirstName}}")
+            .text_body("Hi, {{FirstName}}")
+            .message_stream("broadcast")
+            .messages(vec![BulkMessage {
+                to: "receiver1@example.com".to_string(),
+                template_model: Some(json!({"FirstName":"Bob"})),
+                ..Default::default()
+            }])
+            .build();
+
+        let resp = req.execute(&client).await.expect("json decode");
+        assert_eq!(resp.status, "Accepted");
+    }
+}

--- a/src/api/data_removal.rs
+++ b/src/api/data_removal.rs
@@ -1,0 +1,7 @@
+//! Data Removal API endpoints.
+
+mod create_data_removal;
+mod get_data_removal_status;
+
+pub use create_data_removal::*;
+pub use get_data_removal_status::*;

--- a/src/api/data_removal/create_data_removal.rs
+++ b/src/api/data_removal/create_data_removal.rs
@@ -1,0 +1,65 @@
+use std::borrow::Cow;
+
+use crate::Endpoint;
+use serde::{Deserialize, Serialize};
+use typed_builder::TypedBuilder;
+
+#[derive(Debug, Clone, PartialEq, Serialize, TypedBuilder)]
+#[serde(rename_all = "PascalCase")]
+pub struct CreateDataRemovalRequest {
+    pub requested_by: String,
+    pub requested_for: String,
+    pub notify_when_completed: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct DataRemovalStatusResponse {
+    #[serde(rename = "ID")]
+    pub id: isize,
+    pub status: String,
+}
+
+impl Endpoint for CreateDataRemovalRequest {
+    type Request = CreateDataRemovalRequest;
+    type Response = DataRemovalStatusResponse;
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        "/data-removals".into()
+    }
+
+    fn body(&self) -> &Self::Request {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httptest::matchers::request;
+    use httptest::{responders::*, Expectation, Server};
+    use serde_json::json;
+
+    use crate::reqwest::PostmarkClient;
+    use crate::Query;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn create_data_removal() {
+        let server = Server::run();
+        server.expect(
+            Expectation::matching(request::method_path("POST", "/data-removals"))
+                .respond_with(json_encoded(json!({"ID": 1234, "Status": "Pending"}))),
+        );
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+        let req = CreateDataRemovalRequest::builder()
+            .requested_by("a@example.com".to_string())
+            .requested_for("b@example.com".to_string())
+            .notify_when_completed(true)
+            .build();
+        let resp = req.execute(&client).await.expect("json decode");
+        assert_eq!(resp.status, "Pending");
+    }
+}

--- a/src/api/data_removal/get_data_removal_status.rs
+++ b/src/api/data_removal/get_data_removal_status.rs
@@ -1,0 +1,59 @@
+use std::borrow::Cow;
+
+use crate::api::data_removal::DataRemovalStatusResponse;
+use crate::Endpoint;
+use serde::Serialize;
+use typed_builder::TypedBuilder;
+
+#[derive(Debug, Clone, PartialEq, Serialize, TypedBuilder)]
+#[serde(rename_all = "PascalCase")]
+pub struct GetDataRemovalStatusRequest {
+    #[serde(skip)]
+    pub data_removal_id: isize,
+}
+
+impl Endpoint for GetDataRemovalStatusRequest {
+    type Request = GetDataRemovalStatusRequest;
+    type Response = DataRemovalStatusResponse;
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("/data-removals/{}", self.data_removal_id).into()
+    }
+
+    fn body(&self) -> &Self::Request {
+        self
+    }
+
+    fn method(&self) -> http::Method {
+        http::Method::GET
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httptest::matchers::request;
+    use httptest::{responders::*, Expectation, Server};
+    use serde_json::json;
+
+    use crate::reqwest::PostmarkClient;
+    use crate::Query;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn get_data_removal_status() {
+        let server = Server::run();
+        server.expect(
+            Expectation::matching(request::method_path("GET", "/data-removals/1234"))
+                .respond_with(json_encoded(json!({"ID": 1234, "Status": "Done"}))),
+        );
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+        let req = GetDataRemovalStatusRequest::builder()
+            .data_removal_id(1234)
+            .build();
+        let resp = req.execute(&client).await.expect("json decode");
+        assert_eq!(resp.status, "Done");
+    }
+}

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -3,6 +3,7 @@
 pub use create_server::*;
 pub use delete_server::*;
 pub use edit_server::*;
+pub use edit_server_by_id::*;
 pub use get_current_server::*;
 pub use get_server::*;
 pub use list_servers::*;
@@ -12,6 +13,7 @@ use std::fmt;
 mod create_server;
 mod delete_server;
 mod edit_server;
+mod edit_server_by_id;
 mod get_current_server;
 mod get_server;
 mod list_servers;

--- a/src/api/server/edit_server_by_id.rs
+++ b/src/api/server/edit_server_by_id.rs
@@ -1,0 +1,83 @@
+use std::borrow::Cow;
+
+use crate::api::server::{DeliveryType, Server, ServerColor};
+use crate::Endpoint;
+use serde::Serialize;
+use typed_builder::TypedBuilder;
+
+#[derive(Debug, Clone, PartialEq, Serialize, TypedBuilder)]
+#[serde(rename_all = "PascalCase")]
+pub struct EditServerByIdRequest {
+    #[serde(skip)]
+    pub server_id: isize,
+    #[builder(default, setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[builder(default, setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<ServerColor>,
+    #[builder(default, setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delivery_type: Option<DeliveryType>,
+    #[builder(default, setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub smtp_api_activated: Option<bool>,
+}
+
+impl Endpoint for EditServerByIdRequest {
+    type Request = EditServerByIdRequest;
+    type Response = Server;
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("/servers/{}", self.server_id).into()
+    }
+
+    fn body(&self) -> &Self::Request {
+        self
+    }
+
+    fn method(&self) -> http::Method {
+        http::Method::PUT
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httptest::matchers::request;
+    use httptest::{responders::*, Expectation, Server as HttpServer};
+    use serde_json::json;
+
+    use crate::reqwest::PostmarkClient;
+    use crate::Query;
+
+    use super::*;
+
+    #[tokio::test]
+    pub async fn edit_server_by_id() {
+        let server = HttpServer::run();
+
+        server.expect(
+            Expectation::matching(request::method_path("PUT", "/servers/1")).respond_with(
+                json_encoded(json!({
+                    "ID": 1,
+                    "Name": "Production 2",
+                    "ApiTokens": ["server token"],
+                    "SmtpApiActivated": true
+                })),
+            ),
+        );
+
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+
+        let req = EditServerByIdRequest::builder()
+            .server_id(1)
+            .name("Production 2")
+            .build();
+
+        let resp = req.execute(&client).await.expect("json decode");
+        assert_eq!(resp.id, 1);
+        assert_eq!(resp.name, "Production 2");
+    }
+}

--- a/src/api/signatures.rs
+++ b/src/api/signatures.rs
@@ -1,0 +1,82 @@
+//! Sender signatures API endpoints.
+
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+
+mod create_signature;
+mod delete_signature;
+mod edit_signature;
+mod get_signature;
+mod list_signatures;
+mod resend_signature_confirmation;
+
+pub use create_signature::*;
+pub use delete_signature::*;
+pub use edit_signature::*;
+pub use get_signature::*;
+pub use list_signatures::*;
+pub use resend_signature_confirmation::*;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct SenderSignature {
+    pub domain: String,
+    pub email_address: String,
+    pub reply_to_email_address: Option<String>,
+    pub name: String,
+    pub confirmed: bool,
+    #[serde(rename = "SPFVerified")]
+    pub spf_verified: Option<bool>,
+    #[serde(rename = "SPFHost")]
+    pub spf_host: Option<String>,
+    #[serde(rename = "SPFTextValue")]
+    pub spf_text_value: Option<String>,
+    #[serde(rename = "DKIMVerified")]
+    pub dkim_verified: bool,
+    #[serde(rename = "WeakDKIM")]
+    pub weak_dkim: bool,
+    #[serde(rename = "DKIMHost")]
+    pub dkim_host: Option<String>,
+    #[serde(rename = "DKIMTextValue")]
+    pub dkim_text_value: Option<String>,
+    #[serde(rename = "DKIMPendingHost")]
+    pub dkim_pending_host: Option<String>,
+    #[serde(rename = "DKIMPendingTextValue")]
+    pub dkim_pending_text_value: Option<String>,
+    #[serde(rename = "DKIMRevokedHost")]
+    pub dkim_revoked_host: Option<String>,
+    #[serde(rename = "DKIMRevokedTextValue")]
+    pub dkim_revoked_text_value: Option<String>,
+    pub safe_to_remove_revoked_key_from_dns: Option<bool>,
+    #[serde(rename = "DKIMUpdateStatus")]
+    pub dkim_update_status: Option<String>,
+    pub return_path_domain: Option<String>,
+    pub return_path_domain_verified: Option<bool>,
+    pub return_path_domain_cname_value: Option<String>,
+    #[serde(rename = "ID")]
+    pub id: isize,
+    pub confirmation_personal_note: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct SenderSignatureSummary {
+    pub domain: String,
+    pub email_address: String,
+    pub reply_to_email_address: Option<String>,
+    pub name: String,
+    pub confirmed: bool,
+    #[serde(rename = "ID")]
+    pub id: isize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct BasicApiResponse {
+    pub error_code: isize,
+    pub message: String,
+}
+
+pub(crate) fn paginated_endpoint(path: &str, count: isize, offset: isize) -> Cow<'static, str> {
+    format!("{path}?count={count}&offset={offset}").into()
+}

--- a/src/api/signatures/create_signature.rs
+++ b/src/api/signatures/create_signature.rs
@@ -1,0 +1,77 @@
+use std::borrow::Cow;
+
+use crate::api::signatures::SenderSignature;
+use crate::Endpoint;
+use serde::Serialize;
+use typed_builder::TypedBuilder;
+
+#[derive(Debug, Clone, PartialEq, Serialize, TypedBuilder)]
+#[serde(rename_all = "PascalCase")]
+pub struct CreateSignatureRequest {
+    #[serde(rename = "FromEmail")]
+    pub from_email: String,
+    pub name: String,
+    #[builder(default, setter(into, strip_option))]
+    #[serde(rename = "ReplyToEmail", skip_serializing_if = "Option::is_none")]
+    pub reply_to_email: Option<String>,
+    #[builder(default, setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub return_path_domain: Option<String>,
+    #[builder(default, setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confirmation_personal_note: Option<String>,
+}
+
+impl Endpoint for CreateSignatureRequest {
+    type Request = CreateSignatureRequest;
+    type Response = SenderSignature;
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        "/senders".into()
+    }
+
+    fn body(&self) -> &Self::Request {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httptest::matchers::request;
+    use httptest::{responders::*, Expectation, Server};
+    use serde_json::json;
+
+    use crate::reqwest::PostmarkClient;
+    use crate::Query;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn create_signature() {
+        let server = Server::run();
+        server.expect(
+            Expectation::matching(request::method_path("POST", "/senders")).respond_with(
+                json_encoded(json!({
+                    "Domain": "example.com",
+                    "EmailAddress": "john@example.com",
+                    "ReplyToEmailAddress": "reply@example.com",
+                    "Name": "John",
+                    "Confirmed": false,
+                    "SPFVerified": false,
+                    "DKIMVerified": false,
+                    "WeakDKIM": false,
+                    "ID": 1
+                })),
+            ),
+        );
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+        let req = CreateSignatureRequest::builder()
+            .from_email("john@example.com".to_string())
+            .name("John".to_string())
+            .build();
+        let resp = req.execute(&client).await.expect("json decode");
+        assert_eq!(resp.id, 1);
+    }
+}

--- a/src/api/signatures/delete_signature.rs
+++ b/src/api/signatures/delete_signature.rs
@@ -1,0 +1,58 @@
+use std::borrow::Cow;
+
+use crate::api::signatures::BasicApiResponse;
+use crate::Endpoint;
+use serde::Serialize;
+use typed_builder::TypedBuilder;
+
+#[derive(Debug, Clone, PartialEq, Serialize, TypedBuilder)]
+#[serde(rename_all = "PascalCase")]
+pub struct DeleteSignatureRequest {
+    #[serde(skip)]
+    pub signature_id: isize,
+}
+
+impl Endpoint for DeleteSignatureRequest {
+    type Request = DeleteSignatureRequest;
+    type Response = BasicApiResponse;
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("/senders/{}", self.signature_id).into()
+    }
+
+    fn body(&self) -> &Self::Request {
+        self
+    }
+
+    fn method(&self) -> http::Method {
+        http::Method::DELETE
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httptest::matchers::request;
+    use httptest::{responders::*, Expectation, Server};
+    use serde_json::json;
+
+    use crate::reqwest::PostmarkClient;
+    use crate::Query;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn delete_signature() {
+        let server = Server::run();
+        server.expect(
+            Expectation::matching(request::method_path("DELETE", "/senders/1")).respond_with(
+                json_encoded(json!({"ErrorCode": 0, "Message": "Signature removed."})),
+            ),
+        );
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+        let req = DeleteSignatureRequest::builder().signature_id(1).build();
+        let resp = req.execute(&client).await.expect("json decode");
+        assert_eq!(resp.error_code, 0);
+    }
+}

--- a/src/api/signatures/edit_signature.rs
+++ b/src/api/signatures/edit_signature.rs
@@ -1,0 +1,82 @@
+use std::borrow::Cow;
+
+use crate::api::signatures::SenderSignature;
+use crate::Endpoint;
+use serde::Serialize;
+use typed_builder::TypedBuilder;
+
+#[derive(Debug, Clone, PartialEq, Serialize, TypedBuilder)]
+#[serde(rename_all = "PascalCase")]
+pub struct EditSignatureRequest {
+    #[serde(skip)]
+    pub signature_id: isize,
+    pub name: String,
+    #[builder(default, setter(into, strip_option))]
+    #[serde(rename = "ReplyToEmail", skip_serializing_if = "Option::is_none")]
+    pub reply_to_email: Option<String>,
+    #[builder(default, setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub return_path_domain: Option<String>,
+    #[builder(default, setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confirmation_personal_note: Option<String>,
+}
+
+impl Endpoint for EditSignatureRequest {
+    type Request = EditSignatureRequest;
+    type Response = SenderSignature;
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("/senders/{}", self.signature_id).into()
+    }
+
+    fn body(&self) -> &Self::Request {
+        self
+    }
+
+    fn method(&self) -> http::Method {
+        http::Method::PUT
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httptest::matchers::request;
+    use httptest::{responders::*, Expectation, Server};
+    use serde_json::json;
+
+    use crate::reqwest::PostmarkClient;
+    use crate::Query;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn edit_signature() {
+        let server = Server::run();
+        server.expect(
+            Expectation::matching(request::method_path("PUT", "/senders/1")).respond_with(
+                json_encoded(json!({
+                    "Domain": "example.com",
+                    "EmailAddress": "john@example.com",
+                    "ReplyToEmailAddress": "jane@example.com",
+                    "Name": "Jane Doe",
+                    "Confirmed": false,
+                    "SPFVerified": false,
+                    "DKIMVerified": false,
+                    "WeakDKIM": false,
+                    "ID": 1
+                })),
+            ),
+        );
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+        let req = EditSignatureRequest::builder()
+            .signature_id(1)
+            .name("Jane Doe".to_string())
+            .reply_to_email("jane@example.com".to_string())
+            .build();
+        let resp = req.execute(&client).await.expect("json decode");
+        assert_eq!(resp.name, "Jane Doe");
+    }
+}

--- a/src/api/signatures/get_signature.rs
+++ b/src/api/signatures/get_signature.rs
@@ -1,0 +1,68 @@
+use std::borrow::Cow;
+
+use crate::api::signatures::SenderSignature;
+use crate::Endpoint;
+use serde::Serialize;
+use typed_builder::TypedBuilder;
+
+#[derive(Debug, Clone, PartialEq, Serialize, TypedBuilder)]
+#[serde(rename_all = "PascalCase")]
+pub struct GetSignatureRequest {
+    #[serde(skip)]
+    pub signature_id: isize,
+}
+
+impl Endpoint for GetSignatureRequest {
+    type Request = GetSignatureRequest;
+    type Response = SenderSignature;
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("/senders/{}", self.signature_id).into()
+    }
+
+    fn body(&self) -> &Self::Request {
+        self
+    }
+
+    fn method(&self) -> http::Method {
+        http::Method::GET
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httptest::matchers::request;
+    use httptest::{responders::*, Expectation, Server};
+    use serde_json::json;
+
+    use crate::reqwest::PostmarkClient;
+    use crate::Query;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn get_signature() {
+        let server = Server::run();
+        server.expect(
+            Expectation::matching(request::method_path("GET", "/senders/1")).respond_with(
+                json_encoded(json!({
+                    "Domain": "example.com",
+                    "EmailAddress": "john@example.com",
+                    "ReplyToEmailAddress": "reply@example.com",
+                    "Name": "John",
+                    "Confirmed": true,
+                    "SPFVerified": false,
+                    "DKIMVerified": true,
+                    "WeakDKIM": false,
+                    "ID": 1
+                })),
+            ),
+        );
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+        let req = GetSignatureRequest::builder().signature_id(1).build();
+        let resp = req.execute(&client).await.expect("json decode");
+        assert_eq!(resp.id, 1);
+    }
+}

--- a/src/api/signatures/list_signatures.rs
+++ b/src/api/signatures/list_signatures.rs
@@ -1,0 +1,77 @@
+use std::borrow::Cow;
+
+use crate::api::signatures::{paginated_endpoint, SenderSignatureSummary};
+use crate::Endpoint;
+use serde::{Deserialize, Serialize};
+use typed_builder::TypedBuilder;
+
+#[derive(Debug, Clone, PartialEq, Serialize, TypedBuilder)]
+#[serde(rename_all = "PascalCase")]
+pub struct ListSignaturesRequest {
+    #[serde(skip)]
+    pub count: isize,
+    #[serde(skip)]
+    pub offset: isize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ListSignaturesResponse {
+    pub total_count: isize,
+    pub sender_signatures: Vec<SenderSignatureSummary>,
+}
+
+impl Endpoint for ListSignaturesRequest {
+    type Request = ListSignaturesRequest;
+    type Response = ListSignaturesResponse;
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        paginated_endpoint("/senders", self.count, self.offset)
+    }
+
+    fn body(&self) -> &Self::Request {
+        self
+    }
+
+    fn method(&self) -> http::Method {
+        http::Method::GET
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httptest::matchers::request;
+    use httptest::{responders::*, Expectation, Server};
+    use serde_json::json;
+
+    use crate::reqwest::PostmarkClient;
+    use crate::Query;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn list_signatures() {
+        let server = Server::run();
+        server.expect(
+            Expectation::matching(request::method_path("GET", "/senders")).respond_with(
+                json_encoded(json!({
+                  "TotalCount": 1,
+                  "SenderSignatures": [{
+                    "Domain": "example.com",
+                    "EmailAddress": "john@example.com",
+                    "ReplyToEmailAddress": "reply@example.com",
+                    "Name": "John",
+                    "Confirmed": true,
+                    "ID": 1
+                  }]
+                })),
+            ),
+        );
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+        let req = ListSignaturesRequest::builder().count(50).offset(0).build();
+        let resp = req.execute(&client).await.expect("json decode");
+        assert_eq!(resp.total_count, 1);
+    }
+}

--- a/src/api/signatures/resend_signature_confirmation.rs
+++ b/src/api/signatures/resend_signature_confirmation.rs
@@ -1,0 +1,56 @@
+use std::borrow::Cow;
+
+use crate::api::signatures::BasicApiResponse;
+use crate::Endpoint;
+use serde::Serialize;
+use typed_builder::TypedBuilder;
+
+#[derive(Debug, Clone, PartialEq, Serialize, TypedBuilder)]
+#[serde(rename_all = "PascalCase")]
+pub struct ResendSignatureConfirmationRequest {
+    #[serde(skip)]
+    pub signature_id: isize,
+}
+
+impl Endpoint for ResendSignatureConfirmationRequest {
+    type Request = ResendSignatureConfirmationRequest;
+    type Response = BasicApiResponse;
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("/senders/{}/resend", self.signature_id).into()
+    }
+
+    fn body(&self) -> &Self::Request {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httptest::matchers::request;
+    use httptest::{responders::*, Expectation, Server};
+    use serde_json::json;
+
+    use crate::reqwest::PostmarkClient;
+    use crate::Query;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn resend_signature_confirmation() {
+        let server = Server::run();
+        server.expect(
+            Expectation::matching(request::method_path("POST", "/senders/1/resend")).respond_with(
+                json_encoded(json!({"ErrorCode": 0, "Message": "Confirmation resent."})),
+            ),
+        );
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+        let req = ResendSignatureConfirmationRequest::builder()
+            .signature_id(1)
+            .build();
+        let resp = req.execute(&client).await.expect("json decode");
+        assert_eq!(resp.error_code, 0);
+    }
+}

--- a/src/api/stats.rs
+++ b/src/api/stats.rs
@@ -1,0 +1,38 @@
+//! Stats API endpoints.
+
+use std::borrow::Cow;
+
+use serde::Serialize;
+
+mod stats_outbound;
+pub use stats_outbound::*;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Default)]
+pub struct StatsQuery {
+    pub tag: Option<String>,
+    pub fromdate: Option<String>,
+    pub todate: Option<String>,
+    pub messagestream: Option<String>,
+}
+
+pub(crate) fn stats_endpoint(path: &str, query: &StatsQuery) -> Cow<'static, str> {
+    let mut params: Vec<String> = Vec::new();
+    if let Some(tag) = &query.tag {
+        params.push(format!("tag={tag}"));
+    }
+    if let Some(fromdate) = &query.fromdate {
+        params.push(format!("fromdate={fromdate}"));
+    }
+    if let Some(todate) = &query.todate {
+        params.push(format!("todate={todate}"));
+    }
+    if let Some(messagestream) = &query.messagestream {
+        params.push(format!("messagestream={messagestream}"));
+    }
+
+    if params.is_empty() {
+        path.to_string().into()
+    } else {
+        format!("{path}?{}", params.join("&")).into()
+    }
+}

--- a/src/api/stats/stats_outbound.rs
+++ b/src/api/stats/stats_outbound.rs
@@ -1,0 +1,444 @@
+use std::borrow::Cow;
+
+use crate::api::stats::{stats_endpoint, StatsQuery};
+use crate::Endpoint;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use typed_builder::TypedBuilder;
+
+#[derive(Debug, Clone, PartialEq, Serialize, TypedBuilder)]
+#[serde(rename_all = "PascalCase")]
+pub struct GetOutboundOverviewRequest {
+    #[builder(default)]
+    #[serde(skip)]
+    pub query: StatsQuery,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct OutboundOverviewResponse {
+    pub sent: isize,
+    pub bounced: isize,
+    #[serde(rename = "SMTPApiErrors")]
+    pub smtp_api_errors: isize,
+    pub bounce_rate: f64,
+    pub spam_complaints: isize,
+    pub spam_complaints_rate: f64,
+    pub opens: isize,
+    pub unique_opens: isize,
+    pub total_clicks: isize,
+    pub unique_links_clicked: isize,
+    pub total_tracked_links_sent: isize,
+    pub tracked: isize,
+    pub with_link_tracking: isize,
+    pub with_open_tracking: isize,
+    pub with_client_recorded: isize,
+    pub with_platform_recorded: isize,
+}
+
+impl Endpoint for GetOutboundOverviewRequest {
+    type Request = GetOutboundOverviewRequest;
+    type Response = OutboundOverviewResponse;
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        stats_endpoint("/stats/outbound", &self.query)
+    }
+
+    fn body(&self) -> &Self::Request {
+        self
+    }
+
+    fn method(&self) -> http::Method {
+        http::Method::GET
+    }
+}
+
+macro_rules! stats_req {
+    ($name:ident, $path:expr, $resp:ty) => {
+        #[derive(Debug, Clone, PartialEq, Serialize, TypedBuilder)]
+        #[serde(rename_all = "PascalCase")]
+        pub struct $name {
+            #[builder(default)]
+            #[serde(skip)]
+            pub query: StatsQuery,
+        }
+
+        impl Endpoint for $name {
+            type Request = $name;
+            type Response = $resp;
+
+            fn endpoint(&self) -> Cow<'static, str> {
+                stats_endpoint($path, &self.query)
+            }
+
+            fn body(&self) -> &Self::Request {
+                self
+            }
+
+            fn method(&self) -> http::Method {
+                http::Method::GET
+            }
+        }
+    };
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct SentCountsResponse {
+    pub days: Vec<Value>,
+    pub sent: isize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct BounceCountsResponse {
+    pub days: Vec<Value>,
+    pub hard_bounce: isize,
+    #[serde(rename = "SMTPApiError")]
+    pub smtp_api_error: isize,
+    pub soft_bounce: isize,
+    pub transient: isize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct SpamCountsResponse {
+    pub days: Vec<Value>,
+    pub spam_complaint: isize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct TrackedCountsResponse {
+    pub days: Vec<Value>,
+    pub tracked: isize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct OpensCountsResponse {
+    pub days: Vec<Value>,
+    pub opens: isize,
+    pub unique: isize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct OpensPlatformsResponse {
+    pub days: Vec<Value>,
+    pub desktop: isize,
+    pub mobile: isize,
+    pub unknown: isize,
+    #[serde(rename = "WebMail")]
+    pub web_mail: isize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DynamicKeyCountsResponse {
+    #[serde(rename = "Days")]
+    pub days: Vec<Value>,
+    #[serde(flatten)]
+    pub totals: Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ClickCountsResponse {
+    pub days: Vec<Value>,
+    pub clicks: isize,
+    pub unique: isize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ClickPlatformsResponse {
+    pub days: Vec<Value>,
+    pub desktop: isize,
+    pub mobile: isize,
+    pub unknown: isize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ClickLocationResponse {
+    pub days: Vec<Value>,
+    #[serde(rename = "HTML")]
+    pub html: isize,
+    #[serde(rename = "Text")]
+    pub text: isize,
+}
+
+stats_req!(
+    GetSentCountsRequest,
+    "/stats/outbound/sends",
+    SentCountsResponse
+);
+stats_req!(
+    GetBounceCountsRequest,
+    "/stats/outbound/bounces",
+    BounceCountsResponse
+);
+stats_req!(
+    GetSpamComplaintsRequest,
+    "/stats/outbound/spam",
+    SpamCountsResponse
+);
+stats_req!(
+    GetTrackedEmailCountsRequest,
+    "/stats/outbound/tracked",
+    TrackedCountsResponse
+);
+stats_req!(
+    GetEmailOpenCountsRequest,
+    "/stats/outbound/opens",
+    OpensCountsResponse
+);
+stats_req!(
+    GetEmailPlatformUsageRequest,
+    "/stats/outbound/opens/platforms",
+    OpensPlatformsResponse
+);
+stats_req!(
+    GetEmailClientUsageRequest,
+    "/stats/outbound/opens/emailclients",
+    DynamicKeyCountsResponse
+);
+stats_req!(
+    GetClickCountsRequest,
+    "/stats/outbound/clicks",
+    ClickCountsResponse
+);
+stats_req!(
+    GetBrowserUsageRequest,
+    "/stats/outbound/clicks/browserfamilies",
+    DynamicKeyCountsResponse
+);
+stats_req!(
+    GetBrowserPlatformUsageRequest,
+    "/stats/outbound/clicks/platforms",
+    ClickPlatformsResponse
+);
+stats_req!(
+    GetClickLocationRequest,
+    "/stats/outbound/clicks/location",
+    ClickLocationResponse
+);
+
+#[cfg(test)]
+mod tests {
+    use httptest::matchers::request;
+    use httptest::{responders::*, Expectation, Server};
+    use serde_json::json;
+
+    use crate::reqwest::PostmarkClient;
+    use crate::Query;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn get_outbound_overview() {
+        let server = Server::run();
+        server.expect(
+            Expectation::matching(request::method_path("GET", "/stats/outbound")).respond_with(
+                json_encoded(json!({
+                    "Sent":615,"Bounced":64,"SMTPApiErrors":25,"BounceRate":10.406,
+                    "SpamComplaints":10,"SpamComplaintsRate":1.626,
+                    "Opens":166,"UniqueOpens":26,"TotalClicks":72,
+                    "UniqueLinksClicked":30,"TotalTrackedLinksSent":60,
+                    "Tracked":111,"WithLinkTracking":90,"WithOpenTracking":51,
+                    "WithClientRecorded":14,"WithPlatformRecorded":10
+                })),
+            ),
+        );
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+        let req = GetOutboundOverviewRequest::builder().build();
+        let resp = req.execute(&client).await.expect("json decode");
+        assert_eq!(resp.sent, 615);
+    }
+
+    #[tokio::test]
+    async fn get_sent_counts() {
+        let server = Server::run();
+        server.expect(
+            Expectation::matching(request::method_path("GET", "/stats/outbound/sends"))
+                .respond_with(json_encoded(json!({"Days": [], "Sent": 615}))),
+        );
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+        let req = GetSentCountsRequest::builder().build();
+        let resp = req.execute(&client).await.expect("json decode");
+        assert_eq!(resp.sent, 615);
+    }
+
+    #[tokio::test]
+    async fn get_bounce_counts() {
+        let server = Server::run();
+        server.expect(
+            Expectation::matching(request::method_path("GET", "/stats/outbound/bounces"))
+                .respond_with(json_encoded(json!({"Days":[],"HardBounce":12,"SMTPApiError":25,"SoftBounce":36,"Transient":16}))),
+        );
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+        let req = GetBounceCountsRequest::builder().build();
+        let resp = req.execute(&client).await.expect("json decode");
+        assert_eq!(resp.hard_bounce, 12);
+    }
+
+    #[tokio::test]
+    async fn get_spam_counts() {
+        let server = Server::run();
+        server.expect(
+            Expectation::matching(request::method_path("GET", "/stats/outbound/spam"))
+                .respond_with(json_encoded(json!({"Days":[],"SpamComplaint":10}))),
+        );
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+        let req = GetSpamComplaintsRequest::builder().build();
+        let resp = req.execute(&client).await.expect("json decode");
+        assert_eq!(resp.spam_complaint, 10);
+    }
+
+    #[tokio::test]
+    async fn get_tracked_counts() {
+        let server = Server::run();
+        server.expect(
+            Expectation::matching(request::method_path("GET", "/stats/outbound/tracked"))
+                .respond_with(json_encoded(json!({"Days":[],"Tracked":111}))),
+        );
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+        let req = GetTrackedEmailCountsRequest::builder().build();
+        let resp = req.execute(&client).await.expect("json decode");
+        assert_eq!(resp.tracked, 111);
+    }
+
+    #[tokio::test]
+    async fn get_open_counts() {
+        let server = Server::run();
+        server.expect(
+            Expectation::matching(request::method_path("GET", "/stats/outbound/opens"))
+                .respond_with(json_encoded(json!({"Days":[],"Opens":166,"Unique":26}))),
+        );
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+        let req = GetEmailOpenCountsRequest::builder().build();
+        let resp = req.execute(&client).await.expect("json decode");
+        assert_eq!(resp.unique, 26);
+    }
+
+    #[tokio::test]
+    async fn get_open_platforms() {
+        let server = Server::run();
+        server.expect(
+            Expectation::matching(request::method_path(
+                "GET",
+                "/stats/outbound/opens/platforms",
+            ))
+            .respond_with(json_encoded(
+                json!({"Days":[],"Desktop":4,"Mobile":2,"Unknown":2,"WebMail":2}),
+            )),
+        );
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+        let req = GetEmailPlatformUsageRequest::builder().build();
+        let resp = req.execute(&client).await.expect("json decode");
+        assert_eq!(resp.desktop, 4);
+    }
+
+    #[tokio::test]
+    async fn get_open_clients() {
+        let server = Server::run();
+        server.expect(
+            Expectation::matching(request::method_path(
+                "GET",
+                "/stats/outbound/opens/emailclients",
+            ))
+            .respond_with(json_encoded(json!({"Days":[],"Apple Mail":6}))),
+        );
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+        let req = GetEmailClientUsageRequest::builder().build();
+        let resp = req.execute(&client).await.expect("json decode");
+        assert!(resp.totals.get("Apple Mail").is_some());
+    }
+
+    #[tokio::test]
+    async fn get_click_counts() {
+        let server = Server::run();
+        server.expect(
+            Expectation::matching(request::method_path("GET", "/stats/outbound/clicks"))
+                .respond_with(json_encoded(json!({"Days":[],"Clicks":166,"Unique":26}))),
+        );
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+        let req = GetClickCountsRequest::builder().build();
+        let resp = req.execute(&client).await.expect("json decode");
+        assert_eq!(resp.clicks, 166);
+    }
+
+    #[tokio::test]
+    async fn get_browser_usage() {
+        let server = Server::run();
+        server.expect(
+            Expectation::matching(request::method_path(
+                "GET",
+                "/stats/outbound/clicks/browserfamilies",
+            ))
+            .respond_with(json_encoded(json!({"Days":[],"Google Chrome":6}))),
+        );
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+        let req = GetBrowserUsageRequest::builder().build();
+        let resp = req.execute(&client).await.expect("json decode");
+        assert!(resp.totals.get("Google Chrome").is_some());
+    }
+
+    #[tokio::test]
+    async fn get_browser_platform_usage() {
+        let server = Server::run();
+        server.expect(
+            Expectation::matching(request::method_path(
+                "GET",
+                "/stats/outbound/clicks/platforms",
+            ))
+            .respond_with(json_encoded(
+                json!({"Days":[],"Desktop":4,"Mobile":2,"Unknown":2}),
+            )),
+        );
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+        let req = GetBrowserPlatformUsageRequest::builder().build();
+        let resp = req.execute(&client).await.expect("json decode");
+        assert_eq!(resp.mobile, 2);
+    }
+
+    #[tokio::test]
+    async fn get_click_location() {
+        let server = Server::run();
+        server.expect(
+            Expectation::matching(request::method_path(
+                "GET",
+                "/stats/outbound/clicks/location",
+            ))
+            .respond_with(json_encoded(json!({"Days":[],"HTML":4,"Text":4}))),
+        );
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+        let req = GetClickLocationRequest::builder().build();
+        let resp = req.execute(&client).await.expect("json decode");
+        assert_eq!(resp.html, 4);
+    }
+}

--- a/src/api/triggers.rs
+++ b/src/api/triggers.rs
@@ -1,0 +1,9 @@
+//! Inbound rules triggers API endpoints.
+
+mod create_inbound_rule_trigger;
+mod delete_inbound_rule_trigger;
+mod list_inbound_rule_triggers;
+
+pub use create_inbound_rule_trigger::*;
+pub use delete_inbound_rule_trigger::*;
+pub use list_inbound_rule_triggers::*;

--- a/src/api/triggers/create_inbound_rule_trigger.rs
+++ b/src/api/triggers/create_inbound_rule_trigger.rs
@@ -1,0 +1,56 @@
+use std::borrow::Cow;
+
+use crate::api::triggers::InboundRule;
+use crate::Endpoint;
+use serde::Serialize;
+use typed_builder::TypedBuilder;
+
+#[derive(Debug, Clone, PartialEq, Serialize, TypedBuilder)]
+#[serde(rename_all = "PascalCase")]
+pub struct CreateInboundRuleTriggerRequest {
+    pub rule: String,
+}
+
+impl Endpoint for CreateInboundRuleTriggerRequest {
+    type Request = CreateInboundRuleTriggerRequest;
+    type Response = InboundRule;
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        "/triggers/inboundrules".into()
+    }
+
+    fn body(&self) -> &Self::Request {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httptest::matchers::request;
+    use httptest::{responders::*, Expectation, Server};
+    use serde_json::json;
+
+    use crate::reqwest::PostmarkClient;
+    use crate::Query;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn create_inbound_rule_trigger() {
+        let server = Server::run();
+        server.expect(
+            Expectation::matching(request::method_path("POST", "/triggers/inboundrules"))
+                .respond_with(json_encoded(
+                    json!({"ID": 15, "Rule": "someone@example.com"}),
+                )),
+        );
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+        let req = CreateInboundRuleTriggerRequest::builder()
+            .rule("someone@example.com".to_string())
+            .build();
+        let resp = req.execute(&client).await.expect("json decode");
+        assert_eq!(resp.id, 15);
+    }
+}

--- a/src/api/triggers/delete_inbound_rule_trigger.rs
+++ b/src/api/triggers/delete_inbound_rule_trigger.rs
@@ -1,0 +1,67 @@
+use std::borrow::Cow;
+
+use crate::Endpoint;
+use serde::{Deserialize, Serialize};
+use typed_builder::TypedBuilder;
+
+#[derive(Debug, Clone, PartialEq, Serialize, TypedBuilder)]
+#[serde(rename_all = "PascalCase")]
+pub struct DeleteInboundRuleTriggerRequest {
+    #[serde(skip)]
+    pub trigger_id: isize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct DeleteInboundRuleTriggerResponse {
+    pub error_code: isize,
+    pub message: String,
+}
+
+impl Endpoint for DeleteInboundRuleTriggerRequest {
+    type Request = DeleteInboundRuleTriggerRequest;
+    type Response = DeleteInboundRuleTriggerResponse;
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("/triggers/inboundrules/{}", self.trigger_id).into()
+    }
+
+    fn body(&self) -> &Self::Request {
+        self
+    }
+
+    fn method(&self) -> http::Method {
+        http::Method::DELETE
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httptest::matchers::request;
+    use httptest::{responders::*, Expectation, Server};
+    use serde_json::json;
+
+    use crate::reqwest::PostmarkClient;
+    use crate::Query;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn delete_inbound_rule_trigger() {
+        let server = Server::run();
+        server.expect(
+            Expectation::matching(request::method_path("DELETE", "/triggers/inboundrules/15"))
+                .respond_with(json_encoded(
+                    json!({"ErrorCode": 0, "Message": "Rule removed."}),
+                )),
+        );
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+        let req = DeleteInboundRuleTriggerRequest::builder()
+            .trigger_id(15)
+            .build();
+        let resp = req.execute(&client).await.expect("json decode");
+        assert_eq!(resp.error_code, 0);
+    }
+}

--- a/src/api/triggers/list_inbound_rule_triggers.rs
+++ b/src/api/triggers/list_inbound_rule_triggers.rs
@@ -1,0 +1,83 @@
+use std::borrow::Cow;
+
+use crate::Endpoint;
+use serde::{Deserialize, Serialize};
+use typed_builder::TypedBuilder;
+
+#[derive(Debug, Clone, PartialEq, Serialize, TypedBuilder)]
+#[serde(rename_all = "PascalCase")]
+pub struct ListInboundRuleTriggersRequest {
+    #[serde(skip)]
+    pub count: isize,
+    #[serde(skip)]
+    pub offset: isize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct InboundRule {
+    #[serde(rename = "ID")]
+    pub id: isize,
+    pub rule: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ListInboundRuleTriggersResponse {
+    pub total_count: isize,
+    pub inbound_rules: Vec<InboundRule>,
+}
+
+impl Endpoint for ListInboundRuleTriggersRequest {
+    type Request = ListInboundRuleTriggersRequest;
+    type Response = ListInboundRuleTriggersResponse;
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!(
+            "/triggers/inboundrules?count={}&offset={}",
+            self.count, self.offset
+        )
+        .into()
+    }
+
+    fn body(&self) -> &Self::Request {
+        self
+    }
+
+    fn method(&self) -> http::Method {
+        http::Method::GET
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httptest::matchers::request;
+    use httptest::{responders::*, Expectation, Server};
+    use serde_json::json;
+
+    use crate::reqwest::PostmarkClient;
+    use crate::Query;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn list_inbound_rule_triggers() {
+        let server = Server::run();
+        server.expect(
+            Expectation::matching(request::method_path("GET", "/triggers/inboundrules"))
+                .respond_with(json_encoded(json!({
+                    "TotalCount": 1,
+                    "InboundRules": [{"ID": 3, "Rule": "someone@example.com"}]
+                }))),
+        );
+        let client = PostmarkClient::builder()
+            .base_url(server.url("/").to_string())
+            .build();
+        let req = ListInboundRuleTriggersRequest::builder()
+            .count(50)
+            .offset(0)
+            .build();
+        let resp = req.execute(&client).await.expect("json decode");
+        assert_eq!(resp.total_count, 1);
+    }
+}


### PR DESCRIPTION
## Summary
- Implement remaining requested sections: Servers edit-by-id, Bulk, Sender Signatures (non-deprecated), Stats, Triggers: inbound rules, Data Removal.
- Add endpoint-level tests for each new request type and keep endpoint-per-file module style.
- Add API coverage docs: endpoint matrix, compatibility notes, update workflow, and runnable examples under `docs/api/`.

## Validation
- `cargo fmt`
- `cargo test` (85 unit pass, 19 doc-tests pass)
- `cargo clippy --all-targets`

## Attention Areas
- Deprecated sender-signature endpoints intentionally excluded (`verifyspf`, `requestnewdkim`).
- Messages API remains out of scope and still not implemented.